### PR TITLE
Add unlock metadata and Korean names to secrets

### DIFF
--- a/ui_secrets.csv
+++ b/ui_secrets.csv
@@ -1,641 +1,641 @@
-﻿SecretID,SecretName,Korean,UnlockedFlag
-1,Magdalene,,1
-2,Cain,,1
-3,Judas,,1
-4,The Womb,,1
-5,The Harbingers,,1
-6,A Cube of Meat,고기조각,1
-7,The Book of Revelations,요한묵시록,1
-8,A Noose,,1
-9,The Nail,대못,1
-10,A Quarter,쿼터,1
-11,A Fetus in a Jar,,1
-12,A Small Rock,,1
-13,Monstro's Tooth,몬스트로의 이빨,1
-14,Lil' Chubby,,1
-15,Loki's Horns,로키의 뿔,1
-16,Something From The Future,,1
-17,Something Cute,,1
-18,Something Sticky,,1
-19,A Bandage,,1
-20,A Cross,,1
-21,A Bag of Pennies,,1
-22,The Book of Sin,죄악의 책,1
-23,Little Gish,리틀 기쉬,1
-24,Little Steven,리틀 스티븐,1
-25,Little C.H.A.D.,리틀 차드,1
-26,A Gamekid,,1
-27,A Halo,,1
-28,Mr. Mega,미스터 메가,1
-29,The D6,주사위,1
-30,The Scissors,가위,1
-31,The Parasite,기생충,1
-32,???,???,1
-33,Everything Is Terrible!!!,,1
-34,It Lives!,,1
-35,Mom's Contact,,1
-36,The Necronomicon,네크로노미콘,1
-37,Basement Boy,,1
-38,Spelunker Boy,,1
-39,Dark Boy,,1
-40,Mama's Boy,,1
-41,Golden God!,,1
-42,Eve,,1
-43,Mom's Knife,엄마의 식칼,1
-44,The Razor,,1
-45,Guardian Angel,수호천사,1
-46,A Bag of Bombs,,1
-47,Demon Baby,악마 아기,1
-48,Forget Me Now,날 잊어 주세요,1
-49,The D20,20면 주사위,1
-50,Celtic Cross,켈트 십자가,1
-51,Abel,아벨,1
-52,Curved Horn,휘어진 뿔,1
-53,Sacrificial Dagger,희생의 단도,1
-54,Bloody Lust,피의 욕망,1
-55,Blood Penny,,1
-56,Blood Rights,피의 권리,1
-57,The Polaroid,즉석사진,1
-58,Dad's Key,아빠의 열쇠,1
-59,Blue Candle,,1
-60,Burnt Penny,타버린 동전,1
-61,Lucky Toe,행운의 발가락,1
-62,Epic Fetus,쩌는 태아,1
-63,SMB Super Fan,슈미보 광팬,1
-64,Counterfeit Coin,,1
-65,Guppy's Hairball,구피의 털뭉치,1
-66,A Forgotten Horseman,,1
-67,Samson,,1
-68,Something Icky,,1
-69,!Platinum God!,,1
-70,Isaac's Head,아이작의 머리,1
-71,Maggy's Faith,매기의 믿음,1
-72,Judas' Tongue,유다의 혀,1
-73,???'s Soul,???의 영혼,1
-74,Samson's Lock,삼손의 머리채,1
-75,Cain's Eye,카인의 오른쪽 눈,1
-76,Eve's Bird Foot,이브의 새 다리,1
-77,The Left Hand,왼손목,1
-78,The Negative,반전사진,1
-79,Azazel,,1
-80,Lazarus,,1
-81,Eden,,1
-82,The Lost,,1
-83,Dead Boy,,1
-84,The Real Platinum God,,1
-85,Lucky Rock,행운의 돌조각,1
-86,The Cellar,,1
-87,The Catacombs,,1
-88,The Necropolis,,1
-89,Rune of Hagalaz,,1
-90,Rune of Jera,,1
-91,Rune of Ehwaz,,1
-92,Rune of Dagaz,,1
-93,Rune of Ansuz,,1
-94,Rune of Perthro,,1
-95,Rune of Berkano,,1
-96,Rune of Algiz,,1
-97,Chaos Card,혼돈 카드,1
-98,Credit Card,신용카드,1
-99,Rules Card,규칙 카드,1
-100,Card Against Humanity,,1
-101,Swallowed Penny,삼킨 동전,1
-102,Robo-Baby 2.0,로보 아기 2.0,1
-103,Death's Touch,죽음의 손길,1
-104,Technology .5,,1
-105,Missing No.,,1
-106,Isaac's Tears,아이작의 눈물,1
-107,Guillotine,단두대,1
-108,Judas' Shadow,유다의 그림자,1
-109,Maggy's Bow,매기의 리본,1
-110,Cain's Other Eye,카인의 왼쪽 눈,1
-111,Black Lipstick,검은 립스틱,1
-112,Eve's Mascara,이브의 마스카라,1
-113,Fate,운명,1
-114,???'s Only Friend,???의 하나뿐인한 친구,1
-115,Samson's Chains,삼손의 쇠사슬,1
-116,Lazarus' Rags,나사로의 붕대,1
-117,Broken Ankh,부서진 앙크,1
-118,Store Credit,상점 상품권,1
-119,Pandora's Box,판도라의 상자,1
-120,Suicide King,자살 왕,1
-121,Blank Card,빈 카드,1
-122,Book of Secrets,비밀의 책,1
-123,Mysterious Paper,신비한 종이,1
-124,Mystery Sack,수수께끼의 주머니,1
-125,Undefined,,1
-126,Satanic Bible,사탄경,1
-127,Daemon's Tail,악마 꼬리,1
-128,Abaddon,아바돈,1
-129,Isaac's Heart,아이작의 심장,1
-130,The Mind,정신,1
-131,The Body,육체,1
-132,The Soul,영혼,1
-133,The D100,100면 주사위,1
-134,Blue Map,파란 지도,1
-135,There's Options,추가 선택권,1
-136,Black Candle,검은 양초,1
-137,Red Candle,빨간 양초,1
-138,Stop Watch,스톱워치,1
-139,Wire Coat Hanger,철제 옷걸이,1
-140,Ipecac,구토제,1
-141,Experimental Treatment,임상시험,1
-142,Krampus,,1
-143,Head of Krampus,크람푸스의 머리,1
-144,Super Meat Boy,,1
-145,Butter Bean,흰강낭콩,1
-146,Little Baggy,작은 주머니,1
-147,Blood Bag,혈액 팩,1
-148,The D4,4면 주사위,1
-149,Missing Poster,실종 포스터,1
-150,Rubber Cement,고무 접착제,1
-151,Store Upgrade lv.1,,1
-152,Store Upgrade lv.2,,1
-153,Store Upgrade lv.3,,1
-154,Store Upgrade lv.4,,1
-155,Angels,,1
-156,Godhead,신,1
-157,Darkness Falls,,1
-158,The Tank,,1
-159,Solar System,,1
-160,Suicide King,자살 왕,1
-161,Cat Got Your Tongue,,1
-162,Demo Man,,1
-163,Cursed!,,1
-164,Glass Cannon,유리 대포,1
-165,The Family Man,,1
-166,Purist,,1
-167,Lost Baby,,1
-168,Cute Baby,,1
-169,Crow Baby,,1
-170,Shadow Baby,,1
-171,Glass Baby,,1
-172,Wrapped Baby,,1
-173,Begotten Baby,,1
-174,Dead Baby,,1
-175,#NAME?,,1
-176,Glitch Baby,,1
-177,Fighting Baby,,1
-178,Lord of the Flies,,1
-179,Fart Baby,,1
-180,Purity,순도,1
-181,D12,12면 주사위,1
-182,Betrayal,배신,1
-183,Fate's Reward,운명의 보상,1
-184,Athame,마법 단검,1
-185,Blind Rage,눈먼 분노,1
-186,Maw of the Void,,1
-187,Empty Vessel,빈 그릇,1
-188,Eden's Blessing,에덴의 축복,1
-189,Sworn Protector,맹세한 수호자,1
-190,Incubus,인큐버스,1
-191,Keeper now holds... A Penny!,,1
-192,Lil' Chest,,1
-193,Censer,향로,1
-194,Evil Eye,악마의 눈,1
-195,My Shadow,내 그림자,1
-196,Cracked Dice,금이 간 주사위,1
-197,Black Feather,검은 깃털,1
-198,Lusty Blood,욕망의 피,1
-199,Lilith,,1
-200,Key Bum,열쇠 거지,1
-201,GB Bug,게임 버그,1
-202,Zodiac,황도궁,1
-203,Box of Friends,친구 상자,1
-204,Rib of Greed,그리드의 갈비뼈,1
-205,Cry Baby,,1
-206,Red Baby,,1
-207,Green Baby,,1
-208,Brown Baby,,1
-209,Blue Baby,,1
-210,Lil' Baby,,1
-211,Rage Baby,,1
-212,Black Baby,,1
-213,Long Baby,,1
-214,Yellow Baby,,1
-215,White Baby,,1
-216,Big Baby,,1
-217,Noose Baby,,1
-218,Rune Bag,룬 가방,1
-219,Cambion Conception,몽마의 자식들,1
-220,Serpent's Kiss,독뱀의 키스,1
-221,Succubus,서큐버스,1
-222,Immaculate Conception,원죄없는 잉태,1
-223,Goat Head Baby,,1
-224,Gold Heart,,1
-225,Get out of Jail Free Card,,1
-226,Gold Bomb,,1
-227,2 new pills,,1
-228,2 new pills,,1
-229,Poker Chip,포커 칩,1
-230,Stud Finder,벽체 탐지기,1
-231,D8,8면 주사위,1
-232,Kidney Stone,신장 결석,1
-233,Blank Rune,비어있는 룬,1
-234,Blue Womb,,1
-235,1001%,,1
-236,Keeper holds Wooden Nickel,,1
-237,Keeper holds Store Key,,1
-238,Deep Pockets,넓은 가방,1
-239,Karma,업보,1
-240,Sticky Nickels,,1
-241,Super Greed Baby,,1
-242,Lucky Pennies,,1
-243,Special Hanging Shopkeepers,,1
-244,Wooden Nickel,나무 동전,1
-245,Cain holds Paperclip,,1
-246,Everything is Terrible 2!!!,,1
-247,Special Shopkeepers,,1
-248,Eve now holds Razor Blade,,1
-249,Store Key,상점 열쇠,1
-250,Lost holds Holy Mantle,,1
-251,Keeper,,1
-252,Hive Baby,,1
-253,Buddy Baby,,1
-254,Colorful Baby,,1
-255,Whore Baby,,1
-256,Cracked Baby,,1
-257,Dripping Baby,,1
-258,Blinding Baby,,1
-259,Sucky Baby,,1
-260,Dark Baby,,1
-261,Picky Baby,,1
-262,Revenge Baby,,1
-263,Belial Baby,,1
-264,Sale Baby,,1
-265,XXXXXXXXL,,1
-266,SPEED!,,1
-267,Blue Bomber,,1
-268,PAY TO PLAY,,1
-269,Have a Heart,,1
-270,I RULE!,,1
-271,BRAINS!,,1
-272,PRIDE DAY!,,1
-273,Onan's Streak,,1
-274,The Guardian,,1
-275,Generosity,,1
-276,Mega,,1
-277,Backasswards,,1
-278,Aprils fool,,1
-279,Pokey Mans,,1
-280,Ultra Hard,,1
-281,PONG,,1
-282,D Infinity,,1
-283,Eucharist,성찬,1
-284,Silver Dollar,은화,1
-285,Shade,셰이드,1
-286,King Baby,아기 왕,1
-287,Bloody Crown,피투성이 왕관,1
-288,Dull Razor,무딘 면도칼,1
-289,Eden's Soul,에덴의 영혼,1
-290,Dark Prince's Crown,,1
-291,Compound Fracture,복합 골절,1
-292,Euthanasia,안락사,1
-293,Holy Card,신성한 카드,1
-294,Crooked Penny,구부러진 동전,1
-295,Void,공허,1
-296,D1,1면 주사위,1
-297,Glyph of Balance,균형의 문장,1
-298,Sack of Sacks,자루 주머니,1
-299,Eye of Belial,벨리알의 눈,1
-300,Meconium,태변,1
-301,Stem Cell,줄기 세포,1
-302,Crow Heart,까마귀 심장,1
-303,Metronome,메트로놈,1
-304,Bat Wing,박쥐 날개,1
-305,Plan C,플랜 C,1
-306,Duality,이중성,1
-307,Dad's Lost Coin,아빠의 잃어버린 동전,1
-308,Eye of Greed,탐욕의 눈,1
-309,Black Rune,검은 룬,1
-310,Locust of Wrath,,1
-311,Locust of Pestilence,역병의 메뚜기,1
-312,Locust of Famine,기근의 메뚜기,1
-313,Locust of Death,죽음의 메뚜기,1
-314,Locust of Conquest,정복의 메뚜기,1
-315,Hushy,허쉬,1
-316,Brown Nugget,갈색 너겟,1
-317,Mort Baby,,1
-318,Smelter,용광로,1
-319,Apollyon Baby,,1
-320,New Area,,1
-321,Once More with Feeling!,,1
-322,Hat trick!,,1
-323,5 Nights at Mom's,,1
-324,Sin collector,,1
-325,Dedication,,1
-326,ZIP!,,1
-327,It's the Key,,1
-328,Mr. Resetter!,,1
-329,Living on the edge,,1
-330,U Broke It!,,1
-331,Laz Bleeds More!,,1
-332,Maggy Now Holds a Pill!,,1
-333,Charged Key,,1
-334,Samson Feels Healthy!,,1
-335,Greed's Gullet,탐욕의 식도,1
-336,The Marathon,,1
-337,RERUN,,1
-338,Delirious,정신착란,1
-339,1000000%,,1
-340,Apollyon,,1
-341,Greedier!,,1
-342,Burning Basement,,1
-343,Flooded Caves,,1
-344,Dank Depths,,1
-345,Scarred Womb,,1
-346,Something wicked this way comes!,,1
-347,Something wicked this way comes+!,,1
-348,The gate is open!,,1
-349,Black Hole,블랙홀,1
-350,Mystery Gift,수수께끼의 선물,1
-351,Sprinkler,스프링클러,1
-352,Angry Fly,성난 파리,1
-353,Bozo,멍청이,1
-354,Broken Modem,고장난 모뎀,1
-355,Buddy in a Box,친구 든 상자,1
-356,Fast Bombs,빠른 폭탄,1
-357,Lil Delirium,꼬마 델리리움,1
-358,Hairpin,머리핀,1
-359,Wooden Cross,나무 십자가,1
-360,Butter!,버터!,1
-361,Huge Growth,거대한 성장,1
-362,Ancient Recall,고대의 부름,1
-363,Era Walk,시간 여행,1
-364,Coupon,쿠폰,1
-365,Telekinesis,염동력,1
-366,Moving Box,수납상자,1
-367,Jumper Cables,점퍼 케이블,1
-368,Leprosy,문둥병,1
-369,Technology Zero,기계장치 0,1
-370,Filigree Feather,세공 깃털,1
-371,Mr. ME!,미 씨!,1
-372,7 Seals,7개의 도장,1
-373,Angelic Prism,천사빛 프리즘,1
-374,Pop!,뽁!,1
-375,Door Stop,문 받침대,1
-376,Death's List,죽음의 살생부,1
-377,Haemolacria,피눈물병,1
-378,Lachryphagy,눈물먹이,1
-379,Schoolbag,책가방,1
-380,Trisagion,삼성송,1
-381,Extension Cord,연장 코드,1
-382,Flat Stone,납작한 돌,1
-383,Sacrificial Altar,희생의 제단,1
-384,Lil Spewer,꼬마 구토쟁이,1
-385,Blanket,담요,1
-386,Marbles,구슬,1
-387,Mystery Egg,이상한 알,1
-388,Rotten Penny,썩은 동전,1
-389,Baby-Bender,아기 초능력자,1
-390,The Forgotten,,1
-391,Bone Heart,,1
-392,Marrow,골수,1
-393,Slipped Rib,빠진 갈비뼈,1
-394,Pointy Rib,날카로운 갈비뼈,1
-395,Jaw Bone,턱뼈,1
-396,Brittle Bones,최약골,1
-397,Divorce Papers,이혼 서류,1
-398,Hallowed Ground,성지,1
-399,Finger Bone,손가락 뼈,1
-400,Dad's Ring,아빠의 반지,1
-401,Book of the Dead,망자의 책,1
-402,Bone Baby,,1
-403,Bound Baby,,1
-404,Bethany,,1
-405,Jacob and Esau,,1
-406,The Planetarium,,1
-407,A Secret Exit,,1
-408,Forgotten Lullaby,잊혀진 자장가,1
-409,Fruity Plum,탱탱한 플럼,1
-410,Plum Flute,플럼 피리,1
-411,Rotten Heart,,1
-412,Dross,,1
-413,Ashpit,,1
-414,Gehenna,,1
-415,Red Key,붉은 열쇠,1
-416,Wisp Baby,,1
-417,Book of Virtues,미덕의 책,1
-418,Urn of Souls,영혼의 항아리,1
-419,Blessed Penny,,1
-420,Alabaster Box,석고 옥합,1
-421,Beth's Faith,베다니의 축복,1
-422,Soul Locket,영혼 로켓,1
-423,Divine Intervention,신의 개입,1
-424,Vade Retro,사탄아 물렀거라,1
-425,Star of Bethlehem,베들레헴의 별,1
-426,Hope Baby,,1
-427,Glowing Baby,,1
-428,Double Baby,,1
-429,The Stairway,천국의 계단,1
-430,Red Stew,붉은 스튜,1
-431,Birthright,생득권,1
-432,Damocles,다모클레스,1
-433,Rock Bottom,밑바닥,1
-434,Inner Child,내면의 아이,1
-435,Vanishing Twin,사라진 쌍둥이,1
-436,Genesis,창세기,1
-437,Suplex!,수플렉스!,1
-438,Solomon's Baby,,1
-439,Illusion Baby,,1
-440,Meat Cleaver,고기 도축칼,1
-441,Options?,선택권?,1
-442,Yuck Heart,역겨운 하트,1
-443,Candy Heart,캔디 하트,1
-444,Guppy's Eye,구피의 눈,1
-445,A Pound of Flesh,살점 한 덩이,1
-446,Akeldama,아겔다마,1
-447,Redemption,회개,1
-448,Eternal D6,이터널 주사위,1
-449,Montezuma's Revenge,몬테주마의 복수,1
-450,Bird Cage,새장,1
-451,Cracked Orb,깨진 오브,1
-452,Bloody Gust,피의 돌풍,1
-453,Empty Heart,비어있는 심장,1
-454,Devil's Crown,악마의 왕관,1
-455,Lil Abaddon,꼬마 아바돈,1
-456,Tinytoma,타이니토마,1
-457,Astral Projection,유체이탈,1
-458,'M,,1
-459,Everything Jar,모든 게 담긴 병,1
-460,Lost Soul,잃어버린 영혼,1
-461,Hungry Soul,굶주린 영혼,1
-462,Blood Puppy,핏덩이 강아지,1
-463,C Section,제왕절개,1
-464,Keeper's Sack,키퍼의 자루,1
-465,Keeper's Box,키퍼의 상자,1
-466,Lil Portal,꼬마 포탈,1
-467,Worm Friend,지렁이 친구,1
-468,Bone Spurs,골국,1
-469,Spirit Shackles,영혼의 족쇄,1
-470,Revelation,계시,1
-471,Jar of Wisps,도깨비불 든 병,1
-472,Magic Skin,마법의 피부,1
-473,Friend Finder,친구 찾기,1
-474,The Broken,,1
-475,The Dauntless,,1
-476,The Hoarder,,1
-477,The Deceiver,,1
-478,The Soiled,,1
-479,The Curdled,,1
-480,The Savage,,1
-481,The Benighted,,1
-482,The Enigma,,1
-483,The Capricious,,1
-484,The Baleful,,1
-485,The Harlot,,1
-486,The Miser,,1
-487,The Empty,,1
-488,The Fettered,,1
-489,The Zealot,,1
-490,The Deserter,,1
-491,Glitched Crown,글리치 왕관,1
-492,Belly Jelly,벨리 젤리,1
-493,Blue Key,푸른 열쇠,1
-494,Sanguine Bond,핏빛 결속,1
-495,The Swarm,파리 군단,1
-496,Heartbreak,비탄,1
-497,Larynx,후두,1
-498,Azazel's Rage,아자젤의 분노,1
-499,Salvation,구원,1
-500,TMTRAINER,,1
-501,Sacred Orb,성스러운 오브,1
-502,Twisted Pair,뒤틀린 한 쌍,1
-503,Strawman,밀짚인형,1
-504,Echo Chamber,반향효과,1
-505,Isaac's Tomb,아이작의 무덤,1
-506,Vengeful Spirit,복수심의 영혼,1
-507,Esau Jr.,에사우 주니어,1
-508,Bloody Mary,,1
-509,Baptism by Fire,,1
-510,Isaac's Awakening,,1
-511,Seeing Double,,1
-512,Pica Run,,1
-513,Hot Potato,,1
-514,Cantripped!,,1
-515,Red Redemption,,1
-516,DELETE THIS,,1
-517,Dirty Mind,더러운 군집,1
-518,Sigil of Baphomet,바포메트의 인장,1
-519,Purgatory,연옥,1
-520,Spirit Sword,영혼검,1
-521,Broken Glasses,깨진 안경,1
-522,Ice Cube,얼음 큐브,1
-523,Charged Penny,충전된 동전,1
-524,The Fool,,1
-525,The Magician,,1
-526,The High Priestess,,1
-527,The Empress,,1
-528,The Emperor,,1
-529,The Hierophant,,1
-530,The Lovers,,1
-531,The Chariot,,1
-532,Justice,,1
-533,The Hermit,,1
-534,Wheel of Fortune,,1
-535,Strength,,1
-536,The Hanged Man,,1
-537,Death,,1
-538,Temperance,,1
-539,The Devil,,1
-540,The Tower,,1
-541,The Stars,,1
-542,The Sun and the Moon,,1
-543,Judgement,,1
-544,The World,,1
-545,Old Capacitor,오래된 축전기,1
-546,Brimstone Bombs,유황불 폭탄,1
-547,Mega Mush,거대버섯,1
-548,Mom's Lock,엄마의 머리뭉치,1
-549,Dice Bag,주사위 가방,1
-550,Holy Crown,신성한 왕관,1
-551,Mother's Kiss,어머니의 키스,1
-552,Gilded Key,도금 열쇠,1
-553,Lucky Sack,복주머니,1
-554,Your Soul,네 영혼,1
-555,Number Magnet,숫자 자석,1
-556,Dingle Berry,딩글 베리,1
-557,Ring Cap,딱총 화약,1
-558,Strange Key,이상한 열쇠,1
-559,Lil Clot,꼬마 클롯,1
-560,Temporary Tattoo,스티커 문신,1
-561,Swallowed M80,삼킨 M80,1
-562,Wicked Crown,사악한 왕관,1
-563,Azazel's Stump,아자젤의 뿔대,1
-564,Torn Pocket,찢어진 주머니,1
-565,Torn Card,찢어진 카드,1
-566,Nuh Uh!,,1
-567,Modeling Clay,조형 찰흙,1
-568,Kid's Drawing,아이의 그림,1
-569,Crystal Key,수정 열쇠,1
-570,The Twins,쌍둥이,1
-571,Adoption Papers,입양 서류,1
-572,Keeper's Bargain,키퍼의 흥정,1
-573,Cursed Penny,저주받은 동전,1
-574,Cricket Leg,귀뚜라미 다리,1
-575,Apollyon's Best Friend,,1
-576,Polished Bone,연마한 뼈,1
-577,Hollow Heart,텅 빈 심장,1
-578,Expansion Pack,확장팩,1
-579,Beth's Essence,베다니의 정수,1
-580,RC Remote,RC 리모콘,1
-581,Found Soul,되찾은 영혼,1
-582,Member Card,멤버쉽 카드,1
-583,Golden Razor,황금 면도날,1
-584,Spindown Dice,스핀다운 주사위,1
-585,Hypercoagulation,과응고,1
-586,Bag of Crafting,,1
-587,Dark Arts,흑마술,1
-588,IBS,,1
-589,Sumptorium,섬토리움,1
-590,Berserk!,폭주!,1
-591,Hemoptysis,각혈,1
-592,Flip,뒤집기,1
-593,Corrupted Data,,1
-594,Ghost Bombs,유령 폭탄,1
-595,Gello,겔로,1
-596,Keeper's Kin,키퍼의 친척,1
-597,Abyss,무저갱,1
-598,Decap Attack,참수 공격,1
-599,Lemegeton,마도서 레메게톤,1
-600,Anima Sola,아니마 솔라,1
-601,Mega Chest,,1
-602,Queen of Hearts,하트 Q,1
-603,Gold Pill,,1
-604,Black Sack,,1
-605,Charming Poop,,1
-606,Horse Pill,,1
-607,Crane Game,,1
-608,Hell Game,,1
-609,Wooden Chest,,1
-610,Wild Card,와일드 카드,1
-611,Haunted Chest,,1
-612,Fool's Gold,,1
-613,Golden Penny,,1
-614,Rotten Beggar,,1
-615,Golden Battery,,1
-616,Confessional,,1
-617,Golden Trinket,,1
-618,Soul of Isaac,아이작의 영혼,1
-619,Soul of Magdalene,막달레나의 영혼,1
-620,Soul of Cain,카인의 영혼,1
-621,Soul of Judas,유다의 영혼,1
-622,Soul of???,,1
-623,Soul of Eve,이브의 영혼,1
-624,Soul of Samson,삼손의 영혼,1
-625,Soul of Azazel,아자젤의 영혼,1
-626,Soul of Lazarus,나사로의 영혼,1
-627,Soul of Eden,에덴의 영혼,1
-628,Soul of the Lost,로스트의 영혼,1
-629,Soul of Lilith,릴리스의 영혼,1
-630,Soul of the Keeper,키퍼의 영혼,1
-631,Soul of Apollyon,아폴리온의 영혼,1
-632,Soul of the Forgotten,포가튼의 영혼,1
-633,Soul of Bethany,베서니의 영혼,1
-634,Soul of Jacob and Esau,야곱과 에사우의 영혼,1
-635,A Strange Door,,1
-636,Death Certificate,사망 증명서,1
-637,Dead God,,1
-638,Play Online,,1
-639,Win Online,,1
-640,Win Online Daily,,1
+﻿SecretID,SecretName,UnlockName,Type,Korean,UnlockedFlag
+1,Magdalene,Magdalene,,막달레나,1
+2,Cain,Cain,,카인,1
+3,Judas,Judas,,유다,1
+4,The Womb,Womb,,,1
+5,The Harbingers,The Harbingers,Boss,,1
+6,A Cube of Meat,Cube of Meat,Item,고기조각,1
+7,The Book of Revelations,Book of Revelations,Item,요한묵시록,1
+8,A Noose,Transcendence,Item,초월,1
+9,The Nail,The Nail,Item,대못,1
+10,A Quarter,A Quarter,Item,쿼터,1
+11,A Fetus in a Jar,Dr. Fetus,Item,태아 박사,1
+12,A Small Rock,The Small Rock,Item,작은 돌,1
+13,Monstro's Tooth,Monstro's Tooth,Item,몬스트로의 이빨,1
+14,Lil' Chubby,Little Chubby,Item,리틀 처비,1
+15,Loki's Horns,Loki's Horns,Item,로키의 뿔,1
+16,Something From The Future,Steven,Item,스티븐,1
+17,Something Cute,C.H.A.D.,Boss,,1
+18,Something Sticky,Gish,Boss,,1
+19,A Bandage,Super Bandage,Item,슈퍼 밴디지,1
+20,A Cross,The Relic,Item,성유물,1
+21,A Bag of Pennies,Sack of Pennies,Item,동전 주머니,1
+22,The Book of Sin,The Book of Sin,Item,죄악의 책,1
+23,Little Gish,Little Gish,Item,리틀 기쉬,1
+24,Little Steven,Little Steven,Item,리틀 스티븐,1
+25,Little C.H.A.D.,Little C.H.A.D.,Item,리틀 차드,1
+26,A Gamekid,The Gamekid,Item,게임키드,1
+27,A Halo,The Halo,Item,광륜,1
+28,Mr. Mega,Mr. Mega,Item,미스터 메가,1
+29,The D6,The D6,Item,주사위,1
+30,The Scissors,Scissors,Item,가위,1
+31,The Parasite,The Parasite,Item,기생충,1
+32,???,??? (Character),,???,1
+33,Everything Is Terrible!!!,Everything Is Terrible!!!,,,1
+34,It Lives!,It Lives,Boss,,1
+35,Mom's Contact,Mom's Contacts,Item,엄마의 콘텍트렌즈,1
+36,The Necronomicon,The Necronomicon,Item,네크로노미콘,1
+37,Basement Boy,Basement Boy,,,1
+38,Spelunker Boy,Spelunker Boy,,,1
+39,Dark Boy,Dark Boy,,,1
+40,Mama's Boy,Mama's Boy,,,1
+41,Golden God!,Golden God!,,,1
+42,Eve,Eve,,이브,1
+43,Mom's Knife,Mom's Knife,Item,엄마의 식칼,1
+44,The Razor,Razor Blade,Item,면도날,1
+45,Guardian Angel,Guardian Angel,Item,수호천사,1
+46,A Bag of Bombs,Bomb Bag,Item,폭탄 주머니,1
+47,Demon Baby,Demon Baby,Item,악마 아기,1
+48,Forget Me Now,Forget Me Now,Item,날 잊어 주세요,1
+49,The D20,D20,Item,20면 주사위,1
+50,Celtic Cross,Celtic Cross,Item,켈트 십자가,1
+51,Abel,Abel,Item,아벨,1
+52,Curved Horn,Curved Horn,Item,휘어진 뿔,1
+53,Sacrificial Dagger,Sacrificial Dagger,Item,희생의 단도,1
+54,Bloody Lust,Bloody Lust,Item,피의 욕망,1
+55,Blood Penny,Bloody Penny,Item,피 묻은 동전,1
+56,Blood Rights,Blood Rights,Item,피의 권리,1
+57,The Polaroid,The Polaroid,Item,즉석사진,1
+58,Dad's Key,Dad's Key,Item,아빠의 열쇠,1
+59,Blue Candle,The Candle,Item,양초,1
+60,Burnt Penny,Burnt Penny,Item,타버린 동전,1
+61,Lucky Toe,Lucky Toe,Item,행운의 발가락,1
+62,Epic Fetus,Epic Fetus,Item,쩌는 태아,1
+63,SMB Super Fan,SMB Super Fan,Item,슈미보 광팬,1
+64,Counterfeit Coin,Counterfeit Penny,Item,가짜 동전,1
+65,Guppy's Hairball,Guppy's Hairball,Item,구피의 털뭉치,1
+66,A Forgotten Horseman,Conquest,Boss,,1
+67,Samson,Samson,,,1
+68,Something Icky,Triachnid,Boss,,1
+69,!Platinum God!,!Platinum God!,,,1
+70,Isaac's Head,Isaac's Head,Item,아이작의 머리,1
+71,Maggy's Faith,Maggy's Faith,Item,매기의 믿음,1
+72,Judas' Tongue,Judas' Tongue,Item,유다의 혀,1
+73,???'s Soul,???'s Soul,Item,???의 영혼,1
+74,Samson's Lock,Samson's Lock,Item,삼손의 머리채,1
+75,Cain's Eye,Cain's Eye,Item,카인의 오른쪽 눈,1
+76,Eve's Bird Foot,Eve's Bird Foot,Item,이브의 새 다리,1
+77,The Left Hand,The Left Hand,Item,왼손목,1
+78,The Negative,The Negative,Item,반전사진,1
+79,Azazel,Azazel,,아자젤,1
+80,Lazarus,Lazarus,,나사로,1
+81,Eden,Eden,,에덴,1
+82,The Lost,The Lost,,,1
+83,Dead Boy,Dead Boy,,,1
+84,The Real Platinum God,The Real Platinum God,,,1
+85,Lucky Rock,Lucky Rock,Item,행운의 돌조각,1
+86,The Cellar,The Cellar,,,1
+87,The Catacombs,The Catacombs,,,1
+88,The Necropolis,Necropolis,,,1
+89,Rune of Hagalaz,Rune of Hagalaz,Item,하갈라즈,1
+90,Rune of Jera,Rune of Jera,Item,제라,1
+91,Rune of Ehwaz,Rune of Ehwaz,Item,에와즈,1
+92,Rune of Dagaz,Rune of Dagaz,Item,다가즈,1
+93,Rune of Ansuz,Rune of Ansuz,Item,엔수즈,1
+94,Rune of Perthro,Rune of Perthro,Item,페트로,1
+95,Rune of Berkano,Rune of Berkano,Item,벨카노,1
+96,Rune of Algiz,Rune of Algiz,Item,알기즈,1
+97,Chaos Card,Chaos Card,Item,혼돈 카드,1
+98,Credit Card,Credit Card,Item,신용카드,1
+99,Rules Card,Rules Card,Item,규칙 카드,1
+100,Card Against Humanity,A Card Against Humanity,Item,비인간적인 카드,1
+101,Swallowed Penny,Swallowed Penny,Item,삼킨 동전,1
+102,Robo-Baby 2.0,Robo-Baby 2.0,Item,로보 아기 2.0,1
+103,Death's Touch,Death's Touch,Item,죽음의 손길,1
+104,Technology .5,Tech.5,Item,기계 0.5,1
+105,Missing No.,Missing No.,Item,,1
+106,Isaac's Tears,Isaac's Tears,Item,아이작의 눈물,1
+107,Guillotine,Guillotine,Item,단두대,1
+108,Judas' Shadow,Judas' Shadow,Item,유다의 그림자,1
+109,Maggy's Bow,Maggy's Bow,Item,매기의 리본,1
+110,Cain's Other Eye,Cain's Other Eye,Item,카인의 왼쪽 눈,1
+111,Black Lipstick,Black Lipstick,Item,검은 립스틱,1
+112,Eve's Mascara,Eve's Mascara,Item,이브의 마스카라,1
+113,Fate,Fate,Item,운명,1
+114,???'s Only Friend,???'s Only Friend,Item,???의 하나뿐인한 친구,1
+115,Samson's Chains,Samson's Chains,Item,삼손의 쇠사슬,1
+116,Lazarus' Rags,Lazarus' Rags,Item,나사로의 붕대,1
+117,Broken Ankh,Broken Ankh,Item,부서진 앙크,1
+118,Store Credit,Store Credit,Item,상점 상품권,1
+119,Pandora's Box,Pandora's Box,Item,판도라의 상자,1
+120,Suicide King,Suicide King,Item,자살 왕,1
+121,Blank Card,Blank Card,Item,빈 카드,1
+122,Book of Secrets,Book of Secrets,Item,비밀의 책,1
+123,Mysterious Paper,Mysterious Paper,Item,신비한 종이,1
+124,Mystery Sack,Mystery Sack,Item,수수께끼의 주머니,1
+125,Undefined,Undefined,Item,,1
+126,Satanic Bible,Satanic Bible,Item,사탄경,1
+127,Daemon's Tail,Daemon's Tail,Item,악마 꼬리,1
+128,Abaddon,Abaddon,Item,아바돈,1
+129,Isaac's Heart,Isaac's Heart,Item,아이작의 심장,1
+130,The Mind,The Mind,Item,정신,1
+131,The Body,The Body,Item,육체,1
+132,The Soul,The Soul,Item,영혼,1
+133,The D100,D100,Item,100면 주사위,1
+134,Blue Map,Blue Map,Item,파란 지도,1
+135,There's Options,There's Options,Item,추가 선택권,1
+136,Black Candle,Black Candle,Item,검은 양초,1
+137,Red Candle,Red Candle,Item,빨간 양초,1
+138,Stop Watch,Stop Watch,Item,스톱워치,1
+139,Wire Coat Hanger,Wire Coat Hanger,Item,철제 옷걸이,1
+140,Ipecac,Ipecac,Item,구토제,1
+141,Experimental Treatment,Experimental Treatment,Item,임상시험,1
+142,Krampus,Krampus,Boss,,1
+143,Head of Krampus,Head of Krampus,Item,크람푸스의 머리,1
+144,Super Meat Boy,Cube of Meat,Item,고기조각,1
+145,Butter Bean,Butter Bean,Item,흰강낭콩,1
+146,Little Baggy,Little Baggy,Item,작은 주머니,1
+147,Blood Bag,Blood Bag,Item,혈액 팩,1
+148,The D4,D4,Item,4면 주사위,1
+149,Missing Poster,Missing Poster,Item,실종 포스터,1
+150,Rubber Cement,Rubber Cement,Item,고무 접착제,1
+151,Store Upgrade lv.1,Store Upgrade lv.1,,,1
+152,Store Upgrade lv.2,Store Upgrade lv.2,,,1
+153,Store Upgrade lv.3,Store Upgrade lv.3,,,1
+154,Store Upgrade lv.4,Store Upgrade lv.4,,,1
+155,Angels,Angel,Boss,,1
+156,Godhead,Godhead,Item,신,1
+157,Darkness Falls,Darkness Falls,,,1
+158,The Tank,The Tank,,,1
+159,Solar System,Solar System,,,1
+160,Suicide King,Suicide King (Challenge),,자살 왕,1
+161,Cat Got Your Tongue,Cat Got Your Tongue,,,1
+162,Demo Man,Demo Man,,,1
+163,Cursed!,Cursed!,,,1
+164,Glass Cannon,Glass Cannon (Challenge),,유리 대포,1
+165,The Family Man,The Family Man,,,1
+166,Purist,Purist,,,1
+167,Lost Baby,Lost Baby,,,1
+168,Cute Baby,Cute Baby,,,1
+169,Crow Baby,Crow Baby,,,1
+170,Shadow Baby,Shadow Baby,,,1
+171,Glass Baby,Glass Baby,,,1
+172,Wrapped Baby,Wrapped Baby,,,1
+173,Begotten Baby,Begotten Baby,,,1
+174,Dead Baby,Dead Baby,,,1
+175,#NAME?,-0- Baby,,,1
+176,Glitch Baby,Glitch Baby,,,1
+177,Fighting Baby,Fighting Baby,,,1
+178,Lord of the Flies,Beelzebub,,,1
+179,Fart Baby,Farting Baby,Item,방귀쟁이 아기,1
+180,Purity,Purity,Item,순도,1
+181,D12,D12,Item,12면 주사위,1
+182,Betrayal,Betrayal,Item,배신,1
+183,Fate's Reward,Fate's Reward,Item,운명의 보상,1
+184,Athame,Athame,Item,마법 단검,1
+185,Blind Rage,Blind Rage,Item,눈먼 분노,1
+186,Maw of the Void,Maw Of The Void,Item,공허의 구렁텅이,1
+187,Empty Vessel,Empty Vessel,Item,빈 그릇,1
+188,Eden's Blessing,Eden's Blessing,Item,에덴의 축복,1
+189,Sworn Protector,Sworn Protector,Item,맹세한 수호자,1
+190,Incubus,Incubus,Item,인큐버스,1
+191,Keeper now holds... A Penny!,Keeper,,키퍼,1
+192,Lil' Chest,Lil Chest,Item,꼬마 상자,1
+193,Censer,Censer,Item,향로,1
+194,Evil Eye,Evil Eye,Item,악마의 눈,1
+195,My Shadow,My Shadow,Item,내 그림자,1
+196,Cracked Dice,Cracked Dice,Item,금이 간 주사위,1
+197,Black Feather,Black Feather,Item,검은 깃털,1
+198,Lusty Blood,Lusty Blood,Item,욕망의 피,1
+199,Lilith,Lilith,,릴리스,1
+200,Key Bum,Key Bum,Item,열쇠 거지,1
+201,GB Bug,GB Bug,Item,게임 버그,1
+202,Zodiac,Zodiac,Item,황도궁,1
+203,Box of Friends,Box of Friends,Item,친구 상자,1
+204,Rib of Greed,Rib of Greed,Item,그리드의 갈비뼈,1
+205,Cry Baby,Cry Baby,,,1
+206,Red Baby,Red Baby,,,1
+207,Green Baby,Green Baby,,,1
+208,Brown Baby,Brown Baby,,,1
+209,Blue Baby,Blue Baby,,,1
+210,Lil' Baby,Lil' Baby,,,1
+211,Rage Baby,Rage Baby,,,1
+212,Black Baby,Black Baby,,,1
+213,Long Baby,Long Baby,,,1
+214,Yellow Baby,Yellow Baby,,,1
+215,White Baby,White Baby,,,1
+216,Big Baby,Big Baby,,,1
+217,Noose Baby,Noose Baby,,,1
+218,Rune Bag,Rune Bag,Item,룬 가방,1
+219,Cambion Conception,Cambion Conception,Item,몽마의 자식들,1
+220,Serpent's Kiss,Serpent's Kiss,Item,독뱀의 키스,1
+221,Succubus,Succubus,Item,서큐버스,1
+222,Immaculate Conception,Immaculate Conception,Item,원죄없는 잉태,1
+223,Goat Head Baby,Goat Head Baby,,,1
+224,Gold Heart,Gold Heart,Item,,1
+225,Get out of Jail Free Card,Get out of Jail Free Card,Item,,1
+226,Gold Bomb,Gold Bomb,,,1
+227,2 new pills,Percs!,Item,진통제!,1
+228,2 new pills,Re-Lax,Item,휴-식,1
+229,Poker Chip,Poker Chip,Item,포커 칩,1
+230,Stud Finder,Stud Finder,Item,벽체 탐지기,1
+231,D8,D8,Item,8면 주사위,1
+232,Kidney Stone,Kidney Stone,Item,신장 결석,1
+233,Blank Rune,Blank Rune (Achievement),Item,비어있는 룬,1
+234,Blue Womb,Blue Womb,,,1
+235,1001%,1001%,,,1
+236,Keeper holds Wooden Nickel,Keeper,,키퍼,1
+237,Keeper holds Store Key,Keeper,,키퍼,1
+238,Deep Pockets,Deep Pockets,Item,넓은 가방,1
+239,Karma,Karma,Item,업보,1
+240,Sticky Nickels,Sticky nickel,,,1
+241,Super Greed Baby,Super Greed Baby,,,1
+242,Lucky Pennies,Lucky penny,,,1
+243,Special Hanging Shopkeepers,Special shopkeeper,Item,,1
+244,Wooden Nickel,Wooden Nickel,Item,나무 동전,1
+245,Cain holds Paperclip,Cain,,카인,1
+246,Everything is Terrible 2!!!,Ultra Greed,Boss,,1
+247,Special Shopkeepers,Special shopkeeper,Item,,1
+248,Eve now holds Razor Blade,Eve,,이브,1
+249,Store Key,Store Key,Item,상점 열쇠,1
+250,Lost holds Holy Mantle,The Lost,,,1
+251,Keeper,Keeper,,키퍼,1
+252,Hive Baby,Hive Baby,,,1
+253,Buddy Baby,Buddy Baby,,,1
+254,Colorful Baby,Colorful Baby,,,1
+255,Whore Baby,Whore Baby,,,1
+256,Cracked Baby,Cracked Baby,,,1
+257,Dripping Baby,Dripping Baby,,,1
+258,Blinding Baby,Blinding Baby,,,1
+259,Sucky Baby,Sucky Baby,,,1
+260,Dark Baby,Dark Baby,,,1
+261,Picky Baby,Picky Baby,,,1
+262,Revenge Baby,Revenge Baby,,,1
+263,Belial Baby,Belial Baby,,,1
+264,Sale Baby,Sale Baby,,,1
+265,XXXXXXXXL,XXXXXXXXL,,,1
+266,SPEED!,SPEED!,,,1
+267,Blue Bomber,Blue Bomber,,,1
+268,PAY TO PLAY,PAY TO PLAY,,,1
+269,Have a Heart,Have a Heart,Item,,1
+270,I RULE!,I RULE!,,,1
+271,BRAINS!,BRAINS!,,,1
+272,PRIDE DAY!,PRIDE DAY!,,,1
+273,Onan's Streak,Onan's Streak,,,1
+274,The Guardian,The Guardian,,,1
+275,Generosity,Greed machine,,,1
+276,Mega,Mega Blast,Item,메가 블래스트,1
+277,Backasswards,Backasswards,,,1
+278,Aprils fool,Aprils Fool,,,1
+279,Pokey Mans,Pokey Mans,,,1
+280,Ultra Hard,Ultra Hard,,,1
+281,PONG,Pong,,,1
+282,D Infinity,D infinity,Item,무한 주사위,1
+283,Eucharist,Eucharist,Item,성찬,1
+284,Silver Dollar,Silver Dollar,Item,은화,1
+285,Shade,Shade,Item,셰이드,1
+286,King Baby,King Baby,Item,아기 왕,1
+287,Bloody Crown,Bloody Crown,Item,피투성이 왕관,1
+288,Dull Razor,Dull Razor,Item,무딘 면도칼,1
+289,Eden's Soul,Eden's Soul,Item,에덴의 영혼,1
+290,Dark Prince's Crown,Dark Prince's Crown,Item,,1
+291,Compound Fracture,Compound Fracture,Item,복합 골절,1
+292,Euthanasia,Euthanasia,Item,안락사,1
+293,Holy Card,Holy Card,Item,신성한 카드,1
+294,Crooked Penny,Crooked Penny,Item,구부러진 동전,1
+295,Void,Void,Item,공허,1
+296,D1,D1,Item,1면 주사위,1
+297,Glyph of Balance,Glyph of Balance,Item,균형의 문장,1
+298,Sack of Sacks,Sack of Sacks,Item,자루 주머니,1
+299,Eye of Belial,Eye of Belial,Item,벨리알의 눈,1
+300,Meconium,Meconium,Item,태변,1
+301,Stem Cell,Stem Cell,Item,줄기 세포,1
+302,Crow Heart,Crow Heart,Item,까마귀 심장,1
+303,Metronome,Metronome,Item,메트로놈,1
+304,Bat Wing,Bat Wing,Item,박쥐 날개,1
+305,Plan C,Plan C,Item,플랜 C,1
+306,Duality,Duality,Item,이중성,1
+307,Dad's Lost Coin,Dad's Lost Coin,Item,아빠의 잃어버린 동전,1
+308,Eye of Greed,Eye of Greed,Item,탐욕의 눈,1
+309,Black Rune,Black Rune,Item,검은 룬,1
+310,Locust of Wrath,Locust of War,Item,전쟁의 메뚜기,1
+311,Locust of Pestilence,Locust of Pestilence,Item,역병의 메뚜기,1
+312,Locust of Famine,Locust of Famine,Item,기근의 메뚜기,1
+313,Locust of Death,Locust of Death,Item,죽음의 메뚜기,1
+314,Locust of Conquest,Locust of Conquest,Item,정복의 메뚜기,1
+315,Hushy,Hushy,Item,허쉬,1
+316,Brown Nugget,Brown Nugget,Item,갈색 너겟,1
+317,Mort Baby,Mort Baby,,,1
+318,Smelter,Smelter,Item,용광로,1
+319,Apollyon Baby,Apollyon Baby,,,1
+320,New Area,The Void,,,1
+321,Once More with Feeling!,Gulp!,Item,꿀꺽!,1
+322,Hat trick!,Ace of Clubs,Item,클로버 A,1
+323,5 Nights at Mom's,Super special rock,,,1
+324,Sin collector,Feels Like I'm Walking on Sunshine!,,,1
+325,Dedication,Horf!,Item,퉤엣!,1
+326,ZIP!,Ace of Diamonds,Item,다이아 A,1
+327,It's the Key,Ace of Spades (Card),,,1
+328,Mr. Resetter!,Mr. Resetter!,,,1
+329,Living on the edge,Ace of Hearts,Item,하트 A,1
+330,U Broke It!,Vurp!,Item,끄어억!,1
+331,Laz Bleeds More!,Lazarus,,나사로,1
+332,Maggy Now Holds a Pill!,Magdalene,,막달레나,1
+333,Charged Key,Charged Key,,,1
+334,Samson Feels Healthy!,Samson,,,1
+335,Greed's Gullet,Greed's Gullet,Item,탐욕의 식도,1
+336,The Marathon,Cracked Crown,Item,금이 간 왕관,1
+337,RERUN,RERUN,,,1
+338,Delirious,Delirious,Item,정신착란,1
+339,1000000%,1000000%,,,1
+340,Apollyon,Apollyon,,아폴리온,1
+341,Greedier!,Greedier Mode,,,1
+342,Burning Basement,Burning Basement,,,1
+343,Flooded Caves,Flooded Caves,,,1
+344,Dank Depths,Dank Depths,,,1
+345,Scarred Womb,Scarred Womb,,,1
+346,Something wicked this way comes!,The Binding of Isaac: Afterbirth,,,1
+347,Something wicked this way comes+!,The Binding of Isaac: Afterbirth †,,,1
+348,The gate is open!,Portal,,,1
+349,Black Hole,Black Hole,Item,블랙홀,1
+350,Mystery Gift,Mystery Gift,Item,수수께끼의 선물,1
+351,Sprinkler,Sprinkler,Item,스프링클러,1
+352,Angry Fly,Angry Fly,Item,성난 파리,1
+353,Bozo,Bozo,Item,멍청이,1
+354,Broken Modem,Broken Modem,Item,고장난 모뎀,1
+355,Buddy in a Box,Buddy in a Box,Item,친구 든 상자,1
+356,Fast Bombs,Fast Bombs,Item,빠른 폭탄,1
+357,Lil Delirium,Lil Delirium,Item,꼬마 델리리움,1
+358,Hairpin,Hairpin,Item,머리핀,1
+359,Wooden Cross,Wooden Cross,Item,나무 십자가,1
+360,Butter!,Butter!,Item,버터!,1
+361,Huge Growth,Huge Growth,Item,거대한 성장,1
+362,Ancient Recall,Ancient Recall,Item,고대의 부름,1
+363,Era Walk,Era Walk,Item,시간 여행,1
+364,Coupon,Coupon,Item,쿠폰,1
+365,Telekinesis,Telekinesis,Item,염동력,1
+366,Moving Box,Moving Box,Item,수납상자,1
+367,Jumper Cables,Jumper Cables,Item,점퍼 케이블,1
+368,Leprosy,Leprosy,Item,문둥병,1
+369,Technology Zero,Technology Zero,Item,기계장치 0,1
+370,Filigree Feather,Filigree Feather,Item,세공 깃털,1
+371,Mr. ME!,Mr. ME!,Item,미 씨!,1
+372,7 Seals,7 Seals,Item,7개의 도장,1
+373,Angelic Prism,Angelic Prism,Item,천사빛 프리즘,1
+374,Pop!,Pop!,Item,뽁!,1
+375,Door Stop,Door Stop,Item,문 받침대,1
+376,Death's List,Death's List,Item,죽음의 살생부,1
+377,Haemolacria,Haemolacria,Item,피눈물병,1
+378,Lachryphagy,Lachryphagy,Item,눈물먹이,1
+379,Schoolbag,Schoolbag,Item,책가방,1
+380,Trisagion,Trisagion,Item,삼성송,1
+381,Extension Cord,Extension Cord,Item,연장 코드,1
+382,Flat Stone,Flat Stone,Item,납작한 돌,1
+383,Sacrificial Altar,Sacrificial Altar,Item,희생의 제단,1
+384,Lil Spewer,Lil Spewer,Item,꼬마 구토쟁이,1
+385,Blanket,Blanket,Item,담요,1
+386,Marbles,Marbles,Item,구슬,1
+387,Mystery Egg,Mystery Egg,Item,이상한 알,1
+388,Rotten Penny,Rotten Penny,Item,썩은 동전,1
+389,Baby-Bender,Baby-Bender,Item,아기 초능력자,1
+390,The Forgotten,The Forgotten,,포가튼,1
+391,Bone Heart,Bone Heart,Item,,1
+392,Marrow,Marrow,Item,골수,1
+393,Slipped Rib,Slipped Rib,Item,빠진 갈비뼈,1
+394,Pointy Rib,Pointy Rib,Item,날카로운 갈비뼈,1
+395,Jaw Bone,Jaw Bone,Item,턱뼈,1
+396,Brittle Bones,Brittle Bones,Item,최약골,1
+397,Divorce Papers,Divorce Papers,Item,이혼 서류,1
+398,Hallowed Ground,Hallowed Ground,Item,성지,1
+399,Finger Bone,Finger Bone,Item,손가락 뼈,1
+400,Dad's Ring,Dad's Ring,Item,아빠의 반지,1
+401,Book of the Dead,Book of the Dead,Item,망자의 책,1
+402,Bone Baby,Bone Baby,,,1
+403,Bound Baby,Bound Baby,,,1
+404,Bethany,Bethany,,베서니,1
+405,Jacob and Esau,Jacob and Esau,,,1
+406,The Planetarium,Planetarium,,,1
+407,A Secret Exit,Downpour,,,1
+408,Forgotten Lullaby,Forgotten Lullaby,Item,잊혀진 자장가,1
+409,Fruity Plum,Fruity Plum,Item,탱탱한 플럼,1
+410,Plum Flute,Plum Flute,Item,플럼 피리,1
+411,Rotten Heart,Rotten Heart,Item,,1
+412,Dross,Dross,,,1
+413,Ashpit,Ashpit,,,1
+414,Gehenna,Gehenna,,,1
+415,Red Key,Red Key,Item,붉은 열쇠,1
+416,Wisp Baby,Wisp Baby,,,1
+417,Book of Virtues,Book of Virtues,Item,미덕의 책,1
+418,Urn of Souls,Urn of Souls,Item,영혼의 항아리,1
+419,Blessed Penny,Blessed Penny,Item,,1
+420,Alabaster Box,Alabaster Box,Item,석고 옥합,1
+421,Beth's Faith,Beth's Faith,Item,베다니의 축복,1
+422,Soul Locket,Soul Locket,Item,영혼 로켓,1
+423,Divine Intervention,Divine Intervention,Item,신의 개입,1
+424,Vade Retro,Vade Retro,Item,사탄아 물렀거라,1
+425,Star of Bethlehem,Star of Bethlehem,Item,베들레헴의 별,1
+426,Hope Baby,Hope Baby,,,1
+427,Glowing Baby,Glowing Baby,,,1
+428,Double Baby,Double Baby,,,1
+429,The Stairway,The Stairway,Item,천국의 계단,1
+430,Red Stew,Red Stew,Item,붉은 스튜,1
+431,Birthright,Birthright,Item,생득권,1
+432,Damocles,Damocles,Item,다모클레스,1
+433,Rock Bottom,Rock Bottom,Item,밑바닥,1
+434,Inner Child,Inner Child,Item,내면의 아이,1
+435,Vanishing Twin,Vanishing Twin,Item,사라진 쌍둥이,1
+436,Genesis,Genesis,Item,창세기,1
+437,Suplex!,Suplex!,Item,수플렉스!,1
+438,Solomon's Baby,Solomon's Baby,,,1
+439,Illusion Baby,Illusion Baby,,,1
+440,Meat Cleaver,Meat Cleaver,Item,고기 도축칼,1
+441,Options?,Options?,Item,선택권?,1
+442,Yuck Heart,Yuck Heart,Item,역겨운 하트,1
+443,Candy Heart,Candy Heart,Item,캔디 하트,1
+444,Guppy's Eye,Guppy's Eye,Item,구피의 눈,1
+445,A Pound of Flesh,A Pound of Flesh,Item,살점 한 덩이,1
+446,Akeldama,Akeldama,Item,아겔다마,1
+447,Redemption,Redemption,Item,회개,1
+448,Eternal D6,Eternal D6,Item,이터널 주사위,1
+449,Montezuma's Revenge,Montezuma's Revenge,Item,몬테주마의 복수,1
+450,Bird Cage,Bird Cage,Item,새장,1
+451,Cracked Orb,Cracked Orb,Item,깨진 오브,1
+452,Bloody Gust,Bloody Gust,Item,피의 돌풍,1
+453,Empty Heart,Empty Heart,Item,비어있는 심장,1
+454,Devil's Crown,Devil's Crown,Item,악마의 왕관,1
+455,Lil Abaddon,Lil Abaddon,Item,꼬마 아바돈,1
+456,Tinytoma,Tinytoma,Item,타이니토마,1
+457,Astral Projection,Astral Projection,Item,유체이탈,1
+458,'M,'M,Item,,1
+459,Everything Jar,Everything Jar,Item,모든 게 담긴 병,1
+460,Lost Soul,Lost Soul,Item,잃어버린 영혼,1
+461,Hungry Soul,Hungry Soul,Item,굶주린 영혼,1
+462,Blood Puppy,Blood Puppy,Item,핏덩이 강아지,1
+463,C Section,C Section,Item,제왕절개,1
+464,Keeper's Sack,Keeper's Sack,Item,키퍼의 자루,1
+465,Keeper's Box,Keeper's Box,Item,키퍼의 상자,1
+466,Lil Portal,Lil Portal,Item,꼬마 포탈,1
+467,Worm Friend,Worm Friend,Item,지렁이 친구,1
+468,Bone Spurs,Bone Spurs,Item,골국,1
+469,Spirit Shackles,Spirit Shackles,Item,영혼의 족쇄,1
+470,Revelation,Revelation,Item,계시,1
+471,Jar of Wisps,Jar of Wisps,Item,도깨비불 든 병,1
+472,Magic Skin,Magic Skin,Item,마법의 피부,1
+473,Friend Finder,Friend Finder,Item,친구 찾기,1
+474,The Broken,Tainted Isaac,,,1
+475,The Dauntless,Tainted Magdalene,,,1
+476,The Hoarder,Tainted Cain,,,1
+477,The Deceiver,Tainted Judas,,,1
+478,The Soiled,Tainted ???,,,1
+479,The Curdled,Tainted Eve,,,1
+480,The Savage,Tainted Samson,,,1
+481,The Benighted,Tainted Azazel,,,1
+482,The Enigma,Tainted Lazarus,,,1
+483,The Capricious,Tainted Eden,,,1
+484,The Baleful,Tainted Lost,,,1
+485,The Harlot,Tainted Lilith,,,1
+486,The Miser,Tainted Keeper,,,1
+487,The Empty,Tainted Apollyon,,,1
+488,The Fettered,Tainted Forgotten,,,1
+489,The Zealot,Tainted Bethany,,,1
+490,The Deserter,Tainted Jacob,Boss,,1
+491,Glitched Crown,Glitched Crown,Item,글리치 왕관,1
+492,Belly Jelly,Belly Jelly,Item,벨리 젤리,1
+493,Blue Key,Blue Key,Item,푸른 열쇠,1
+494,Sanguine Bond,Sanguine Bond,Item,핏빛 결속,1
+495,The Swarm,The Swarm,Item,파리 군단,1
+496,Heartbreak,Heartbreak,Item,비탄,1
+497,Larynx,Larynx,Item,후두,1
+498,Azazel's Rage,Azazel's Rage,Item,아자젤의 분노,1
+499,Salvation,Salvation,Item,구원,1
+500,TMTRAINER,TMTRAINER,Item,,1
+501,Sacred Orb,Sacred Orb,Item,성스러운 오브,1
+502,Twisted Pair,Twisted Pair,Item,뒤틀린 한 쌍,1
+503,Strawman,Strawman,Item,밀짚인형,1
+504,Echo Chamber,Echo Chamber,Item,반향효과,1
+505,Isaac's Tomb,Isaac's Tomb,Item,아이작의 무덤,1
+506,Vengeful Spirit,Vengeful Spirit,Item,복수심의 영혼,1
+507,Esau Jr.,Esau Jr.,Item,에사우 주니어,1
+508,Bloody Mary,Bloody Mary,,,1
+509,Baptism by Fire,Baptism by Fire,,,1
+510,Isaac's Awakening,Isaac's Awakening,,,1
+511,Seeing Double,Seeing Double,,,1
+512,Pica Run,Pica Run,,,1
+513,Hot Potato,Hot Potato,,,1
+514,Cantripped!,Cantripped!,,,1
+515,Red Redemption,Red Redemption,,,1
+516,DELETE THIS,DELETE THIS,,,1
+517,Dirty Mind,Dirty Mind,Item,더러운 군집,1
+518,Sigil of Baphomet,Sigil of Baphomet,Item,바포메트의 인장,1
+519,Purgatory,Purgatory,Item,연옥,1
+520,Spirit Sword,Spirit Sword,Item,영혼검,1
+521,Broken Glasses,Broken Glasses,Item,깨진 안경,1
+522,Ice Cube,Ice Cube,Item,얼음 큐브,1
+523,Charged Penny,Charged Penny,Item,충전된 동전,1
+524,The Fool,The Fool,Item,바보,1
+525,The Magician,The Magician,Item,마법사,1
+526,The High Priestess,The High Priestess,Item,여교황,1
+527,The Empress,The Empress,Item,여제,1
+528,The Emperor,The Emperor,Item,황제,1
+529,The Hierophant,The Hierophant,Item,교황,1
+530,The Lovers,The Lovers,Item,연인,1
+531,The Chariot,The Chariot,Item,전차,1
+532,Justice,Justice,Item,정의,1
+533,The Hermit,The Hermit,Item,은둔자,1
+534,Wheel of Fortune,Wheel of Fortune,Item,운명의 수레바퀴,1
+535,Strength,Strength,Item,힘,1
+536,The Hanged Man,The Hanged Man,Item,매달린 남자,1
+537,Death,Death,Item,죽음,1
+538,Temperance,Temperance,Item,절제,1
+539,The Devil,The Devil,Item,악마,1
+540,The Tower,The Tower,Item,탑,1
+541,The Stars,The Stars,Item,별,1
+542,The Sun and the Moon,The Sun and the Moon,,,1
+543,Judgement,Judgement,Item,심판,1
+544,The World,The World,Item,세계,1
+545,Old Capacitor,Old Capacitor,Item,오래된 축전기,1
+546,Brimstone Bombs,Brimstone Bombs,Item,유황불 폭탄,1
+547,Mega Mush,Mega Mush,Item,거대버섯,1
+548,Mom's Lock,Mom's Lock,Item,엄마의 머리뭉치,1
+549,Dice Bag,Dice Bag,Item,주사위 가방,1
+550,Holy Crown,Holy Crown,Item,신성한 왕관,1
+551,Mother's Kiss,Mother's Kiss,Item,어머니의 키스,1
+552,Gilded Key,Gilded Key,Item,도금 열쇠,1
+553,Lucky Sack,Lucky Sack,Item,복주머니,1
+554,Your Soul,Your Soul,Item,네 영혼,1
+555,Number Magnet,Number Magnet,Item,숫자 자석,1
+556,Dingle Berry,Dingle Berry,Item,딩글 베리,1
+557,Ring Cap,Ring Cap,Item,딱총 화약,1
+558,Strange Key,Strange Key,Item,이상한 열쇠,1
+559,Lil Clot,Lil Clot,Item,꼬마 클롯,1
+560,Temporary Tattoo,Temporary Tattoo,Item,스티커 문신,1
+561,Swallowed M80,Swallowed M80,Item,삼킨 M80,1
+562,Wicked Crown,Wicked Crown,Item,사악한 왕관,1
+563,Azazel's Stump,Azazel's Stump,Item,아자젤의 뿔대,1
+564,Torn Pocket,Torn Pocket,Item,찢어진 주머니,1
+565,Torn Card,Torn Card,Item,찢어진 카드,1
+566,Nuh Uh!,Nuh Uh!,Item,,1
+567,Modeling Clay,Modeling Clay,Item,조형 찰흙,1
+568,Kid's Drawing,Kid's Drawing,Item,아이의 그림,1
+569,Crystal Key,Crystal Key,Item,수정 열쇠,1
+570,The Twins,The Twins,Item,쌍둥이,1
+571,Adoption Papers,Adoption Papers,Item,입양 서류,1
+572,Keeper's Bargain,Keeper's Bargain,Item,키퍼의 흥정,1
+573,Cursed Penny,Cursed Penny,Item,저주받은 동전,1
+574,Cricket Leg,Cricket Leg,Item,귀뚜라미 다리,1
+575,Apollyon's Best Friend,Apollyon's Best Friend,Item,,1
+576,Polished Bone,Polished Bone,Item,연마한 뼈,1
+577,Hollow Heart,Hollow Heart,Item,텅 빈 심장,1
+578,Expansion Pack,Expansion Pack,Item,확장팩,1
+579,Beth's Essence,Beth's Essence,Item,베다니의 정수,1
+580,RC Remote,RC Remote,Item,RC 리모콘,1
+581,Found Soul,Found Soul,Item,되찾은 영혼,1
+582,Member Card,Member Card,Item,멤버쉽 카드,1
+583,Golden Razor,Golden Razor,Item,황금 면도날,1
+584,Spindown Dice,Spindown Dice,Item,스핀다운 주사위,1
+585,Hypercoagulation,Hypercoagulation,Item,과응고,1
+586,Bag of Crafting,Bag of Crafting,Item,,1
+587,Dark Arts,Dark Arts,Item,흑마술,1
+588,IBS,IBS,Item,,1
+589,Sumptorium,Sumptorium,Item,섬토리움,1
+590,Berserk!,Berserk!,Item,폭주!,1
+591,Hemoptysis,Hemoptysis,Item,각혈,1
+592,Flip,Flip,Item,뒤집기,1
+593,Corrupted Data,Corrupted Data,,,1
+594,Ghost Bombs,Ghost Bombs,Item,유령 폭탄,1
+595,Gello,Gello,Item,겔로,1
+596,Keeper's Kin,Keeper's Kin,Item,키퍼의 친척,1
+597,Abyss,Abyss,Item,무저갱,1
+598,Decap Attack,Decap Attack,Item,참수 공격,1
+599,Lemegeton,Lemegeton,Item,마도서 레메게톤,1
+600,Anima Sola,Anima Sola,Item,아니마 솔라,1
+601,Mega Chest,Mega Chest,Item,,1
+602,Queen of Hearts,Queen of Hearts,Item,하트 Q,1
+603,Gold Pill,Gold Pill,Item,,1
+604,Black Sack,Black Sack,Item,,1
+605,Charming Poop,Charming Poop,Item,,1
+606,Horse Pill,Horse Pill,Item,,1
+607,Crane Game,Crane Game,Item,,1
+608,Hell Game,Hell Game,Item,,1
+609,Wooden Chest,Wooden Chest,Item,,1
+610,Wild Card,Wild Card,Item,와일드 카드,1
+611,Haunted Chest,Haunted Chest,Item,,1
+612,Fool's Gold,Fool's Gold,,,1
+613,Golden Penny,Golden Penny,,,1
+614,Rotten Beggar,Rotten Beggar,Item,,1
+615,Golden Battery,Golden Battery,Item,,1
+616,Confessional,Confessional,,,1
+617,Golden Trinket,Golden Trinket,Item,,1
+618,Soul of Isaac,Soul of Isaac,Item,아이작의 영혼,1
+619,Soul of Magdalene,Soul of Magdalene,Item,막달레나의 영혼,1
+620,Soul of Cain,Soul of Cain,Item,카인의 영혼,1
+621,Soul of Judas,Soul of Judas,Item,유다의 영혼,1
+622,Soul of???,Soul of ???,Item,???,1
+623,Soul of Eve,Soul of Eve,Item,이브의 영혼,1
+624,Soul of Samson,Soul of Samson,Item,삼손의 영혼,1
+625,Soul of Azazel,Soul of Azazel,Item,아자젤의 영혼,1
+626,Soul of Lazarus,Soul of Lazarus,Item,나사로의 영혼,1
+627,Soul of Eden,Soul of Eden,Item,에덴의 영혼,1
+628,Soul of the Lost,Soul of the Lost,Item,로스트의 영혼,1
+629,Soul of Lilith,Soul of Lilith,Item,릴리스의 영혼,1
+630,Soul of the Keeper,Soul of the Keeper,Item,키퍼의 영혼,1
+631,Soul of Apollyon,Soul of Apollyon,Item,아폴리온의 영혼,1
+632,Soul of the Forgotten,Soul of the Forgotten,Item,포가튼의 영혼,1
+633,Soul of Bethany,Soul of Bethany,Item,베서니의 영혼,1
+634,Soul of Jacob and Esau,Soul of Jacob and Esau,Item,야곱과 에서의 영혼,1
+635,A Strange Door,A Strange Door,,,1
+636,Death Certificate,Death Certificate,Item,사망 증명서,1
+637,Dead God,Dead God,,,1
+638,Play Online,Play Online,,,1
+639,Win Online,Win Online,,,1
+640,Win Online Daily,Win Online Daily,,,1


### PR DESCRIPTION
## Summary
- add UnlockName and Type columns to ui_secrets.csv and populate them with each secret's unlock target and classification
- fill in Korean names for items, cards, runes, souls, and characters where translations exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0eea83f5c8332856e9f5997133aaa