### PR TITLE
Fix trinket types in ui_secrets

### DIFF
--- a/ui_secrets.csv
+++ b/ui_secrets.csv
@@ -50,32 +50,32 @@
 49,The D20,D20,Item,20면 주사위,1
 50,Celtic Cross,Celtic Cross,Item,켈트 십자가,1
 51,Abel,Abel,Item,아벨,1
-52,Curved Horn,Curved Horn,Item,휘어진 뿔,1
+52,Curved Horn,Curved Horn,Trinket,휘어진 뿔,1
 53,Sacrificial Dagger,Sacrificial Dagger,Item,희생의 단도,1
 54,Bloody Lust,Bloody Lust,Item,피의 욕망,1
-55,Blood Penny,Bloody Penny,Item,피 묻은 동전,1
+55,Blood Penny,Bloody Penny,Trinket,피 묻은 동전,1
 56,Blood Rights,Blood Rights,Item,피의 권리,1
 57,The Polaroid,The Polaroid,Item,즉석사진,1
 58,Dad's Key,Dad's Key,Item,아빠의 열쇠,1
 59,Blue Candle,The Candle,Item,양초,1
-60,Burnt Penny,Burnt Penny,Item,타버린 동전,1
-61,Lucky Toe,Lucky Toe,Item,행운의 발가락,1
+60,Burnt Penny,Burnt Penny,Trinket,타버린 동전,1
+61,Lucky Toe,Lucky Toe,Trinket,행운의 발가락,1
 62,Epic Fetus,Epic Fetus,Item,쩌는 태아,1
 63,SMB Super Fan,SMB Super Fan,Item,슈미보 광팬,1
-64,Counterfeit Coin,Counterfeit Penny,Item,가짜 동전,1
+64,Counterfeit Coin,Counterfeit Penny,Trinket,가짜 동전,1
 65,Guppy's Hairball,Guppy's Hairball,Item,구피의 털뭉치,1
 66,A Forgotten Horseman,Conquest,Boss,,1
 67,Samson,Samson,,,1
 68,Something Icky,Triachnid,Boss,,1
 69,!Platinum God!,!Platinum God!,,,1
-70,Isaac's Head,Isaac's Head,Item,아이작의 머리,1
-71,Maggy's Faith,Maggy's Faith,Item,매기의 믿음,1
-72,Judas' Tongue,Judas' Tongue,Item,유다의 혀,1
-73,???'s Soul,???'s Soul,Item,???의 영혼,1
-74,Samson's Lock,Samson's Lock,Item,삼손의 머리채,1
-75,Cain's Eye,Cain's Eye,Item,카인의 오른쪽 눈,1
-76,Eve's Bird Foot,Eve's Bird Foot,Item,이브의 새 다리,1
-77,The Left Hand,The Left Hand,Item,왼손목,1
+70,Isaac's Head,Isaac's Head,Trinket,아이작의 머리,1
+71,Maggy's Faith,Maggy's Faith,Trinket,매기의 믿음,1
+72,Judas' Tongue,Judas' Tongue,Trinket,유다의 혀,1
+73,???'s Soul,???'s Soul,Trinket,???의 영혼,1
+74,Samson's Lock,Samson's Lock,Trinket,삼손의 머리채,1
+75,Cain's Eye,Cain's Eye,Trinket,카인의 오른쪽 눈,1
+76,Eve's Bird Foot,Eve's Bird Foot,Trinket,이브의 새 다리,1
+77,The Left Hand,The Left Hand,Trinket,왼손목,1
 78,The Negative,The Negative,Item,반전사진,1
 79,Azazel,Azazel,,아자젤,1
 80,Lazarus,Lazarus,,나사로,1
@@ -83,7 +83,7 @@
 82,The Lost,The Lost,,,1
 83,Dead Boy,Dead Boy,,,1
 84,The Real Platinum God,The Real Platinum God,,,1
-85,Lucky Rock,Lucky Rock,Item,행운의 돌조각,1
+85,Lucky Rock,Lucky Rock,Trinket,행운의 돌조각,1
 86,The Cellar,The Cellar,,,1
 87,The Catacombs,The Catacombs,,,1
 88,The Necropolis,Necropolis,,,1
@@ -99,7 +99,7 @@
 98,Credit Card,Credit Card,Item,신용카드,1
 99,Rules Card,Rules Card,Item,규칙 카드,1
 100,Card Against Humanity,A Card Against Humanity,Item,비인간적인 카드,1
-101,Swallowed Penny,Swallowed Penny,Item,삼킨 동전,1
+101,Swallowed Penny,Swallowed Penny,Trinket,삼킨 동전,1
 102,Robo-Baby 2.0,Robo-Baby 2.0,Item,로보 아기 2.0,1
 103,Death's Touch,Death's Touch,Item,죽음의 손길,1
 104,Technology .5,Tech.5,Item,기계 0.5,1
@@ -109,23 +109,23 @@
 108,Judas' Shadow,Judas' Shadow,Item,유다의 그림자,1
 109,Maggy's Bow,Maggy's Bow,Item,매기의 리본,1
 110,Cain's Other Eye,Cain's Other Eye,Item,카인의 왼쪽 눈,1
-111,Black Lipstick,Black Lipstick,Item,검은 립스틱,1
+111,Black Lipstick,Black Lipstick,Trinket,검은 립스틱,1
 112,Eve's Mascara,Eve's Mascara,Item,이브의 마스카라,1
 113,Fate,Fate,Item,운명,1
 114,???'s Only Friend,???'s Only Friend,Item,???의 하나뿐인한 친구,1
 115,Samson's Chains,Samson's Chains,Item,삼손의 쇠사슬,1
 116,Lazarus' Rags,Lazarus' Rags,Item,나사로의 붕대,1
-117,Broken Ankh,Broken Ankh,Item,부서진 앙크,1
-118,Store Credit,Store Credit,Item,상점 상품권,1
+117,Broken Ankh,Broken Ankh,Trinket,부서진 앙크,1
+118,Store Credit,Store Credit,Trinket,상점 상품권,1
 119,Pandora's Box,Pandora's Box,Item,판도라의 상자,1
 120,Suicide King,Suicide King,Item,자살 왕,1
 121,Blank Card,Blank Card,Item,빈 카드,1
 122,Book of Secrets,Book of Secrets,Item,비밀의 책,1
-123,Mysterious Paper,Mysterious Paper,Item,신비한 종이,1
+123,Mysterious Paper,Mysterious Paper,Trinket,신비한 종이,1
 124,Mystery Sack,Mystery Sack,Item,수수께끼의 주머니,1
 125,Undefined,Undefined,Item,,1
 126,Satanic Bible,Satanic Bible,Item,사탄경,1
-127,Daemon's Tail,Daemon's Tail,Item,악마 꼬리,1
+127,Daemon's Tail,Daemon's Tail,Trinket,악마 꼬리,1
 128,Abaddon,Abaddon,Item,아바돈,1
 129,Isaac's Heart,Isaac's Heart,Item,아이작의 심장,1
 130,The Mind,The Mind,Item,정신,1
@@ -147,7 +147,7 @@
 146,Little Baggy,Little Baggy,Item,작은 주머니,1
 147,Blood Bag,Blood Bag,Item,혈액 팩,1
 148,The D4,D4,Item,4면 주사위,1
-149,Missing Poster,Missing Poster,Item,실종 포스터,1
+149,Missing Poster,Missing Poster,Trinket,실종 포스터,1
 150,Rubber Cement,Rubber Cement,Item,고무 접착제,1
 151,Store Upgrade lv.1,Store Upgrade lv.1,,,1
 152,Store Upgrade lv.2,Store Upgrade lv.2,,,1
@@ -183,7 +183,7 @@
 182,Betrayal,Betrayal,Item,배신,1
 183,Fate's Reward,Fate's Reward,Item,운명의 보상,1
 184,Athame,Athame,Item,마법 단검,1
-185,Blind Rage,Blind Rage,Item,눈먼 분노,1
+185,Blind Rage,Blind Rage,Trinket,눈먼 분노,1
 186,Maw of the Void,Maw Of The Void,Item,공허의 구렁텅이,1
 187,Empty Vessel,Empty Vessel,Item,빈 그릇,1
 188,Eden's Blessing,Eden's Blessing,Item,에덴의 축복,1
@@ -194,15 +194,15 @@
 193,Censer,Censer,Item,향로,1
 194,Evil Eye,Evil Eye,Item,악마의 눈,1
 195,My Shadow,My Shadow,Item,내 그림자,1
-196,Cracked Dice,Cracked Dice,Item,금이 간 주사위,1
-197,Black Feather,Black Feather,Item,검은 깃털,1
+196,Cracked Dice,Cracked Dice,Trinket,금이 간 주사위,1
+197,Black Feather,Black Feather,Trinket,검은 깃털,1
 198,Lusty Blood,Lusty Blood,Item,욕망의 피,1
 199,Lilith,Lilith,,릴리스,1
 200,Key Bum,Key Bum,Item,열쇠 거지,1
 201,GB Bug,GB Bug,Item,게임 버그,1
 202,Zodiac,Zodiac,Item,황도궁,1
 203,Box of Friends,Box of Friends,Item,친구 상자,1
-204,Rib of Greed,Rib of Greed,Item,그리드의 갈비뼈,1
+204,Rib of Greed,Rib of Greed,Trinket,그리드의 갈비뼈,1
 205,Cry Baby,Cry Baby,,,1
 206,Red Baby,Red Baby,,,1
 207,Green Baby,Green Baby,,,1
@@ -227,8 +227,8 @@
 226,Gold Bomb,Gold Bomb,,,1
 227,2 new pills,Percs!,Item,진통제!,1
 228,2 new pills,Re-Lax,Item,휴-식,1
-229,Poker Chip,Poker Chip,Item,포커 칩,1
-230,Stud Finder,Stud Finder,Item,벽체 탐지기,1
+229,Poker Chip,Poker Chip,Trinket,포커 칩,1
+230,Stud Finder,Stud Finder,Trinket,벽체 탐지기,1
 231,D8,D8,Item,8면 주사위,1
 232,Kidney Stone,Kidney Stone,Item,신장 결석,1
 233,Blank Rune,Blank Rune (Achievement),Item,비어있는 룬,1
@@ -237,7 +237,7 @@
 236,Keeper holds Wooden Nickel,Keeper,,키퍼,1
 237,Keeper holds Store Key,Keeper,,키퍼,1
 238,Deep Pockets,Deep Pockets,Item,넓은 가방,1
-239,Karma,Karma,Item,업보,1
+239,Karma,Karma,Trinket,업보,1
 240,Sticky Nickels,Sticky nickel,,,1
 241,Super Greed Baby,Super Greed Baby,,,1
 242,Lucky Pennies,Lucky penny,,,1
@@ -247,7 +247,7 @@
 246,Everything is Terrible 2!!!,Ultra Greed,Boss,,1
 247,Special Shopkeepers,Special shopkeeper,Item,,1
 248,Eve now holds Razor Blade,Eve,,이브,1
-249,Store Key,Store Key,Item,상점 열쇠,1
+249,Store Key,Store Key,Trinket,상점 열쇠,1
 250,Lost holds Holy Mantle,The Lost,,,1
 251,Keeper,Keeper,,키퍼,1
 252,Hive Baby,Hive Baby,,,1
@@ -282,10 +282,10 @@
 281,PONG,Pong,,,1
 282,D Infinity,D infinity,Item,무한 주사위,1
 283,Eucharist,Eucharist,Item,성찬,1
-284,Silver Dollar,Silver Dollar,Item,은화,1
+284,Silver Dollar,Silver Dollar,Trinket,은화,1
 285,Shade,Shade,Item,셰이드,1
 286,King Baby,King Baby,Item,아기 왕,1
-287,Bloody Crown,Bloody Crown,Item,피투성이 왕관,1
+287,Bloody Crown,Bloody Crown,Trinket,피투성이 왕관,1
 288,Dull Razor,Dull Razor,Item,무딘 면도칼,1
 289,Eden's Soul,Eden's Soul,Item,에덴의 영혼,1
 290,Dark Prince's Crown,Dark Prince's Crown,Item,,1
@@ -298,21 +298,21 @@
 297,Glyph of Balance,Glyph of Balance,Item,균형의 문장,1
 298,Sack of Sacks,Sack of Sacks,Item,자루 주머니,1
 299,Eye of Belial,Eye of Belial,Item,벨리알의 눈,1
-300,Meconium,Meconium,Item,태변,1
-301,Stem Cell,Stem Cell,Item,줄기 세포,1
-302,Crow Heart,Crow Heart,Item,까마귀 심장,1
+300,Meconium,Meconium,Trinket,태변,1
+301,Stem Cell,Stem Cell,Trinket,줄기 세포,1
+302,Crow Heart,Crow Heart,Trinket,까마귀 심장,1
 303,Metronome,Metronome,Item,메트로놈,1
-304,Bat Wing,Bat Wing,Item,박쥐 날개,1
+304,Bat Wing,Bat Wing,Trinket,박쥐 날개,1
 305,Plan C,Plan C,Item,플랜 C,1
 306,Duality,Duality,Item,이중성,1
 307,Dad's Lost Coin,Dad's Lost Coin,Item,아빠의 잃어버린 동전,1
 308,Eye of Greed,Eye of Greed,Item,탐욕의 눈,1
 309,Black Rune,Black Rune,Item,검은 룬,1
-310,Locust of Wrath,Locust of War,Item,전쟁의 메뚜기,1
-311,Locust of Pestilence,Locust of Pestilence,Item,역병의 메뚜기,1
-312,Locust of Famine,Locust of Famine,Item,기근의 메뚜기,1
-313,Locust of Death,Locust of Death,Item,죽음의 메뚜기,1
-314,Locust of Conquest,Locust of Conquest,Item,정복의 메뚜기,1
+310,Locust of Wrath,Locust of War,Trinket,전쟁의 메뚜기,1
+311,Locust of Pestilence,Locust of Pestilence,Trinket,역병의 메뚜기,1
+312,Locust of Famine,Locust of Famine,Trinket,기근의 메뚜기,1
+313,Locust of Death,Locust of Death,Trinket,죽음의 메뚜기,1
+314,Locust of Conquest,Locust of Conquest,Trinket,정복의 메뚜기,1
 315,Hushy,Hushy,Item,허쉬,1
 316,Brown Nugget,Brown Nugget,Item,갈색 너겟,1
 317,Mort Baby,Mort Baby,,,1
@@ -334,7 +334,7 @@
 333,Charged Key,Charged Key,,,1
 334,Samson Feels Healthy!,Samson,,,1
 335,Greed's Gullet,Greed's Gullet,Item,탐욕의 식도,1
-336,The Marathon,Cracked Crown,Item,금이 간 왕관,1
+336,The Marathon,Cracked Crown,Trinket,금이 간 왕관,1
 337,RERUN,RERUN,,,1
 338,Delirious,Delirious,Item,정신착란,1
 339,1000000%,1000000%,,,1
@@ -356,9 +356,9 @@
 355,Buddy in a Box,Buddy in a Box,Item,친구 든 상자,1
 356,Fast Bombs,Fast Bombs,Item,빠른 폭탄,1
 357,Lil Delirium,Lil Delirium,Item,꼬마 델리리움,1
-358,Hairpin,Hairpin,Item,머리핀,1
-359,Wooden Cross,Wooden Cross,Item,나무 십자가,1
-360,Butter!,Butter!,Item,버터!,1
+358,Hairpin,Hairpin,Trinket,머리핀,1
+359,Wooden Cross,Wooden Cross,Trinket,나무 십자가,1
+360,Butter!,Butter!,Trinket,버터!,1
 361,Huge Growth,Huge Growth,Item,거대한 성장,1
 362,Ancient Recall,Ancient Recall,Item,고대의 부름,1
 363,Era Walk,Era Walk,Item,시간 여행,1
@@ -368,26 +368,26 @@
 367,Jumper Cables,Jumper Cables,Item,점퍼 케이블,1
 368,Leprosy,Leprosy,Item,문둥병,1
 369,Technology Zero,Technology Zero,Item,기계장치 0,1
-370,Filigree Feather,Filigree Feather,Item,세공 깃털,1
+370,Filigree Feather,Filigree Feather,Trinket,세공 깃털,1
 371,Mr. ME!,Mr. ME!,Item,미 씨!,1
 372,7 Seals,7 Seals,Item,7개의 도장,1
 373,Angelic Prism,Angelic Prism,Item,천사빛 프리즘,1
 374,Pop!,Pop!,Item,뽁!,1
-375,Door Stop,Door Stop,Item,문 받침대,1
+375,Door Stop,Door Stop,Trinket,문 받침대,1
 376,Death's List,Death's List,Item,죽음의 살생부,1
 377,Haemolacria,Haemolacria,Item,피눈물병,1
 378,Lachryphagy,Lachryphagy,Item,눈물먹이,1
 379,Schoolbag,Schoolbag,Item,책가방,1
 380,Trisagion,Trisagion,Item,삼성송,1
-381,Extension Cord,Extension Cord,Item,연장 코드,1
+381,Extension Cord,Extension Cord,Trinket,연장 코드,1
 382,Flat Stone,Flat Stone,Item,납작한 돌,1
 383,Sacrificial Altar,Sacrificial Altar,Item,희생의 제단,1
 384,Lil Spewer,Lil Spewer,Item,꼬마 구토쟁이,1
 385,Blanket,Blanket,Item,담요,1
 386,Marbles,Marbles,Item,구슬,1
 387,Mystery Egg,Mystery Egg,Item,이상한 알,1
-388,Rotten Penny,Rotten Penny,Item,썩은 동전,1
-389,Baby-Bender,Baby-Bender,Item,아기 초능력자,1
+388,Rotten Penny,Rotten Penny,Trinket,썩은 동전,1
+389,Baby-Bender,Baby-Bender,Trinket,아기 초능력자,1
 390,The Forgotten,The Forgotten,,포가튼,1
 391,Bone Heart,Bone Heart,Item,,1
 392,Marrow,Marrow,Item,골수,1
@@ -397,7 +397,7 @@
 396,Brittle Bones,Brittle Bones,Item,최약골,1
 397,Divorce Papers,Divorce Papers,Item,이혼 서류,1
 398,Hallowed Ground,Hallowed Ground,Item,성지,1
-399,Finger Bone,Finger Bone,Item,손가락 뼈,1
+399,Finger Bone,Finger Bone,Trinket,손가락 뼈,1
 400,Dad's Ring,Dad's Ring,Item,아빠의 반지,1
 401,Book of the Dead,Book of the Dead,Item,망자의 책,1
 402,Bone Baby,Bone Baby,,,1
@@ -406,7 +406,7 @@
 405,Jacob and Esau,Jacob and Esau,,,1
 406,The Planetarium,Planetarium,,,1
 407,A Secret Exit,Downpour,,,1
-408,Forgotten Lullaby,Forgotten Lullaby,Item,잊혀진 자장가,1
+408,Forgotten Lullaby,Forgotten Lullaby,Trinket,잊혀진 자장가,1
 409,Fruity Plum,Fruity Plum,Item,탱탱한 플럼,1
 410,Plum Flute,Plum Flute,Item,플럼 피리,1
 411,Rotten Heart,Rotten Heart,Item,,1
@@ -417,9 +417,9 @@
 416,Wisp Baby,Wisp Baby,,,1
 417,Book of Virtues,Book of Virtues,Item,미덕의 책,1
 418,Urn of Souls,Urn of Souls,Item,영혼의 항아리,1
-419,Blessed Penny,Blessed Penny,Item,,1
+419,Blessed Penny,Blessed Penny,Trinket,,1
 420,Alabaster Box,Alabaster Box,Item,석고 옥합,1
-421,Beth's Faith,Beth's Faith,Item,베다니의 축복,1
+421,Beth's Faith,Beth's Faith,Trinket,베다니의 축복,1
 422,Soul Locket,Soul Locket,Item,영혼 로켓,1
 423,Divine Intervention,Divine Intervention,Item,신의 개입,1
 424,Vade Retro,Vade Retro,Item,사탄아 물렀거라,1
@@ -452,11 +452,11 @@
 451,Cracked Orb,Cracked Orb,Item,깨진 오브,1
 452,Bloody Gust,Bloody Gust,Item,피의 돌풍,1
 453,Empty Heart,Empty Heart,Item,비어있는 심장,1
-454,Devil's Crown,Devil's Crown,Item,악마의 왕관,1
+454,Devil's Crown,Devil's Crown,Trinket,악마의 왕관,1
 455,Lil Abaddon,Lil Abaddon,Item,꼬마 아바돈,1
 456,Tinytoma,Tinytoma,Item,타이니토마,1
 457,Astral Projection,Astral Projection,Item,유체이탈,1
-458,'M,'M,Item,,1
+458,'M,'M,Trinket,,1
 459,Everything Jar,Everything Jar,Item,모든 게 담긴 병,1
 460,Lost Soul,Lost Soul,Item,잃어버린 영혼,1
 461,Hungry Soul,Hungry Soul,Item,굶주린 영혼,1
@@ -491,7 +491,7 @@
 490,The Deserter,Tainted Jacob,Boss,,1
 491,Glitched Crown,Glitched Crown,Item,글리치 왕관,1
 492,Belly Jelly,Belly Jelly,Item,벨리 젤리,1
-493,Blue Key,Blue Key,Item,푸른 열쇠,1
+493,Blue Key,Blue Key,Trinket,푸른 열쇠,1
 494,Sanguine Bond,Sanguine Bond,Item,핏빛 결속,1
 495,The Swarm,The Swarm,Item,파리 군단,1
 496,Heartbreak,Heartbreak,Item,비탄,1
@@ -516,12 +516,12 @@
 515,Red Redemption,Red Redemption,,,1
 516,DELETE THIS,DELETE THIS,,,1
 517,Dirty Mind,Dirty Mind,Item,더러운 군집,1
-518,Sigil of Baphomet,Sigil of Baphomet,Item,바포메트의 인장,1
+518,Sigil of Baphomet,Sigil of Baphomet,Trinket,바포메트의 인장,1
 519,Purgatory,Purgatory,Item,연옥,1
 520,Spirit Sword,Spirit Sword,Item,영혼검,1
-521,Broken Glasses,Broken Glasses,Item,깨진 안경,1
-522,Ice Cube,Ice Cube,Item,얼음 큐브,1
-523,Charged Penny,Charged Penny,Item,충전된 동전,1
+521,Broken Glasses,Broken Glasses,Trinket,깨진 안경,1
+522,Ice Cube,Ice Cube,Trinket,얼음 큐브,1
+523,Charged Penny,Charged Penny,Trinket,충전된 동전,1
 524,The Fool,The Fool,Item,바보,1
 525,The Magician,The Magician,Item,마법사,1
 526,The High Priestess,The High Priestess,Item,여교황,1
@@ -543,43 +543,43 @@
 542,The Sun and the Moon,The Sun and the Moon,,,1
 543,Judgement,Judgement,Item,심판,1
 544,The World,The World,Item,세계,1
-545,Old Capacitor,Old Capacitor,Item,오래된 축전기,1
+545,Old Capacitor,Old Capacitor,Trinket,오래된 축전기,1
 546,Brimstone Bombs,Brimstone Bombs,Item,유황불 폭탄,1
 547,Mega Mush,Mega Mush,Item,거대버섯,1
-548,Mom's Lock,Mom's Lock,Item,엄마의 머리뭉치,1
-549,Dice Bag,Dice Bag,Item,주사위 가방,1
-550,Holy Crown,Holy Crown,Item,신성한 왕관,1
-551,Mother's Kiss,Mother's Kiss,Item,어머니의 키스,1
-552,Gilded Key,Gilded Key,Item,도금 열쇠,1
-553,Lucky Sack,Lucky Sack,Item,복주머니,1
-554,Your Soul,Your Soul,Item,네 영혼,1
-555,Number Magnet,Number Magnet,Item,숫자 자석,1
-556,Dingle Berry,Dingle Berry,Item,딩글 베리,1
-557,Ring Cap,Ring Cap,Item,딱총 화약,1
-558,Strange Key,Strange Key,Item,이상한 열쇠,1
-559,Lil Clot,Lil Clot,Item,꼬마 클롯,1
-560,Temporary Tattoo,Temporary Tattoo,Item,스티커 문신,1
-561,Swallowed M80,Swallowed M80,Item,삼킨 M80,1
-562,Wicked Crown,Wicked Crown,Item,사악한 왕관,1
-563,Azazel's Stump,Azazel's Stump,Item,아자젤의 뿔대,1
-564,Torn Pocket,Torn Pocket,Item,찢어진 주머니,1
-565,Torn Card,Torn Card,Item,찢어진 카드,1
-566,Nuh Uh!,Nuh Uh!,Item,,1
-567,Modeling Clay,Modeling Clay,Item,조형 찰흙,1
-568,Kid's Drawing,Kid's Drawing,Item,아이의 그림,1
-569,Crystal Key,Crystal Key,Item,수정 열쇠,1
-570,The Twins,The Twins,Item,쌍둥이,1
-571,Adoption Papers,Adoption Papers,Item,입양 서류,1
-572,Keeper's Bargain,Keeper's Bargain,Item,키퍼의 흥정,1
-573,Cursed Penny,Cursed Penny,Item,저주받은 동전,1
-574,Cricket Leg,Cricket Leg,Item,귀뚜라미 다리,1
-575,Apollyon's Best Friend,Apollyon's Best Friend,Item,,1
-576,Polished Bone,Polished Bone,Item,연마한 뼈,1
-577,Hollow Heart,Hollow Heart,Item,텅 빈 심장,1
-578,Expansion Pack,Expansion Pack,Item,확장팩,1
-579,Beth's Essence,Beth's Essence,Item,베다니의 정수,1
-580,RC Remote,RC Remote,Item,RC 리모콘,1
-581,Found Soul,Found Soul,Item,되찾은 영혼,1
+548,Mom's Lock,Mom's Lock,Trinket,엄마의 머리뭉치,1
+549,Dice Bag,Dice Bag,Trinket,주사위 가방,1
+550,Holy Crown,Holy Crown,Trinket,신성한 왕관,1
+551,Mother's Kiss,Mother's Kiss,Trinket,어머니의 키스,1
+552,Gilded Key,Gilded Key,Trinket,도금 열쇠,1
+553,Lucky Sack,Lucky Sack,Trinket,복주머니,1
+554,Your Soul,Your Soul,Trinket,네 영혼,1
+555,Number Magnet,Number Magnet,Trinket,숫자 자석,1
+556,Dingle Berry,Dingle Berry,Trinket,딩글 베리,1
+557,Ring Cap,Ring Cap,Trinket,딱총 화약,1
+558,Strange Key,Strange Key,Trinket,이상한 열쇠,1
+559,Lil Clot,Lil Clot,Trinket,꼬마 클롯,1
+560,Temporary Tattoo,Temporary Tattoo,Trinket,스티커 문신,1
+561,Swallowed M80,Swallowed M80,Trinket,삼킨 M80,1
+562,Wicked Crown,Wicked Crown,Trinket,사악한 왕관,1
+563,Azazel's Stump,Azazel's Stump,Trinket,아자젤의 뿔대,1
+564,Torn Pocket,Torn Pocket,Trinket,찢어진 주머니,1
+565,Torn Card,Torn Card,Trinket,찢어진 카드,1
+566,Nuh Uh!,Nuh Uh!,Trinket,,1
+567,Modeling Clay,Modeling Clay,Trinket,조형 찰흙,1
+568,Kid's Drawing,Kid's Drawing,Trinket,아이의 그림,1
+569,Crystal Key,Crystal Key,Trinket,수정 열쇠,1
+570,The Twins,The Twins,Trinket,쌍둥이,1
+571,Adoption Papers,Adoption Papers,Trinket,입양 서류,1
+572,Keeper's Bargain,Keeper's Bargain,Trinket,키퍼의 흥정,1
+573,Cursed Penny,Cursed Penny,Trinket,저주받은 동전,1
+574,Cricket Leg,Cricket Leg,Trinket,귀뚜라미 다리,1
+575,Apollyon's Best Friend,Apollyon's Best Friend,Trinket,,1
+576,Polished Bone,Polished Bone,Trinket,연마한 뼈,1
+577,Hollow Heart,Hollow Heart,Trinket,텅 빈 심장,1
+578,Expansion Pack,Expansion Pack,Trinket,확장팩,1
+579,Beth's Essence,Beth's Essence,Trinket,베다니의 정수,1
+580,RC Remote,RC Remote,Trinket,RC 리모콘,1
+581,Found Soul,Found Soul,Trinket,되찾은 영혼,1
 582,Member Card,Member Card,Item,멤버쉽 카드,1
 583,Golden Razor,Golden Razor,Item,황금 면도날,1
 584,Spindown Dice,Spindown Dice,Item,스핀다운 주사위,1


### PR DESCRIPTION
## Summary
- update the `Type` column to "Trinket" for achievements that unlock trinkets in `ui_secrets.csv`

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0fc7f97d48332a5047bcf0fea1e91