### PR TITLE
Translate cards and runes in secrets list

### DIFF
--- a/ui_secrets.csv
+++ b/ui_secrets.csv
@@ -87,18 +87,18 @@
 86,The Cellar,The Cellar,,,1
 87,The Catacombs,The Catacombs,,,1
 88,The Necropolis,Necropolis,,,1
-89,Rune of Hagalaz,Rune of Hagalaz,Item,하갈라즈,1
-90,Rune of Jera,Rune of Jera,Item,제라,1
-91,Rune of Ehwaz,Rune of Ehwaz,Item,에와즈,1
-92,Rune of Dagaz,Rune of Dagaz,Item,다가즈,1
-93,Rune of Ansuz,Rune of Ansuz,Item,엔수즈,1
-94,Rune of Perthro,Rune of Perthro,Item,페트로,1
-95,Rune of Berkano,Rune of Berkano,Item,벨카노,1
-96,Rune of Algiz,Rune of Algiz,Item,알기즈,1
-97,Chaos Card,Chaos Card,Item,혼돈 카드,1
-98,Credit Card,Credit Card,Item,신용카드,1
-99,Rules Card,Rules Card,Item,규칙 카드,1
-100,Card Against Humanity,A Card Against Humanity,Item,비인간적인 카드,1
+89,Rune of Hagalaz,Rune of Hagalaz,Rune,하갈라즈,1
+90,Rune of Jera,Rune of Jera,Rune,제라,1
+91,Rune of Ehwaz,Rune of Ehwaz,Rune,에와즈,1
+92,Rune of Dagaz,Rune of Dagaz,Rune,다가즈,1
+93,Rune of Ansuz,Rune of Ansuz,Rune,엔수즈,1
+94,Rune of Perthro,Rune of Perthro,Rune,페트로,1
+95,Rune of Berkano,Rune of Berkano,Rune,벨카노,1
+96,Rune of Algiz,Rune of Algiz,Rune,알기즈,1
+97,Chaos Card,Chaos Card,Card,혼돈 카드,1
+98,Credit Card,Credit Card,Card,신용카드,1
+99,Rules Card,Rules Card,Card,규칙 카드,1
+100,Card Against Humanity,A Card Against Humanity,Card,비인간적인 카드,1
 101,Swallowed Penny,Swallowed Penny,Trinket,삼킨 동전,1
 102,Robo-Baby 2.0,Robo-Baby 2.0,Item,로보 아기 2.0,1
 103,Death's Touch,Death's Touch,Item,죽음의 손길,1
@@ -118,7 +118,7 @@
 117,Broken Ankh,Broken Ankh,Trinket,부서진 앙크,1
 118,Store Credit,Store Credit,Trinket,상점 상품권,1
 119,Pandora's Box,Pandora's Box,Item,판도라의 상자,1
-120,Suicide King,Suicide King,Item,자살 왕,1
+120,Suicide King,Suicide King,Card,자살 왕,1
 121,Blank Card,Blank Card,Item,빈 카드,1
 122,Book of Secrets,Book of Secrets,Item,비밀의 책,1
 123,Mysterious Paper,Mysterious Paper,Trinket,신비한 종이,1
@@ -223,7 +223,7 @@
 222,Immaculate Conception,Immaculate Conception,Item,원죄없는 잉태,1
 223,Goat Head Baby,Goat Head Baby,,,1
 224,Gold Heart,Gold Heart,Item,,1
-225,Get out of Jail Free Card,Get out of Jail Free Card,Item,,1
+225,Get out of Jail Free Card,Get out of Jail Free Card,Card,감옥 탈출 카드,1
 226,Gold Bomb,Gold Bomb,,,1
 227,2 new pills,Percs!,Item,진통제!,1
 228,2 new pills,Re-Lax,Item,휴-식,1
@@ -291,7 +291,7 @@
 290,Dark Prince's Crown,Dark Prince's Crown,Item,,1
 291,Compound Fracture,Compound Fracture,Item,복합 골절,1
 292,Euthanasia,Euthanasia,Item,안락사,1
-293,Holy Card,Holy Card,Item,신성한 카드,1
+293,Holy Card,Holy Card,Card,신성한 카드,1
 294,Crooked Penny,Crooked Penny,Item,구부러진 동전,1
 295,Void,Void,Item,공허,1
 296,D1,D1,Item,1면 주사위,1
@@ -320,14 +320,14 @@
 319,Apollyon Baby,Apollyon Baby,,,1
 320,New Area,The Void,,,1
 321,Once More with Feeling!,Gulp!,Item,꿀꺽!,1
-322,Hat trick!,Ace of Clubs,Item,클로버 A,1
+322,Hat trick!,Ace of Clubs,Card,클로버 A,1
 323,5 Nights at Mom's,Super special rock,,,1
 324,Sin collector,Feels Like I'm Walking on Sunshine!,,,1
 325,Dedication,Horf!,Item,퉤엣!,1
-326,ZIP!,Ace of Diamonds,Item,다이아 A,1
-327,It's the Key,Ace of Spades (Card),,,1
+326,ZIP!,Ace of Diamonds,Card,다이아 A,1
+327,It's the Key,Ace of Spades (Card),Card,스페이드 A,1
 328,Mr. Resetter!,Mr. Resetter!,,,1
-329,Living on the edge,Ace of Hearts,Item,하트 A,1
+329,Living on the edge,Ace of Hearts,Card,하트 A,1
 330,U Broke It!,Vurp!,Item,끄어억!,1
 331,Laz Bleeds More!,Lazarus,,나사로,1
 332,Maggy Now Holds a Pill!,Magdalene,,막달레나,1
@@ -522,27 +522,27 @@
 521,Broken Glasses,Broken Glasses,Trinket,깨진 안경,1
 522,Ice Cube,Ice Cube,Trinket,얼음 큐브,1
 523,Charged Penny,Charged Penny,Trinket,충전된 동전,1
-524,The Fool,The Fool,Item,바보,1
-525,The Magician,The Magician,Item,마법사,1
-526,The High Priestess,The High Priestess,Item,여교황,1
-527,The Empress,The Empress,Item,여제,1
-528,The Emperor,The Emperor,Item,황제,1
-529,The Hierophant,The Hierophant,Item,교황,1
-530,The Lovers,The Lovers,Item,연인,1
-531,The Chariot,The Chariot,Item,전차,1
-532,Justice,Justice,Item,정의,1
-533,The Hermit,The Hermit,Item,은둔자,1
-534,Wheel of Fortune,Wheel of Fortune,Item,운명의 수레바퀴,1
-535,Strength,Strength,Item,힘,1
-536,The Hanged Man,The Hanged Man,Item,매달린 남자,1
-537,Death,Death,Item,죽음,1
-538,Temperance,Temperance,Item,절제,1
-539,The Devil,The Devil,Item,악마,1
-540,The Tower,The Tower,Item,탑,1
-541,The Stars,The Stars,Item,별,1
+524,The Fool,The Fool,Card,바보,1
+525,The Magician,The Magician,Card,마법사,1
+526,The High Priestess,The High Priestess,Card,여교황,1
+527,The Empress,The Empress,Card,여제,1
+528,The Emperor,The Emperor,Card,황제,1
+529,The Hierophant,The Hierophant,Card,교황,1
+530,The Lovers,The Lovers,Card,연인,1
+531,The Chariot,The Chariot,Card,전차,1
+532,Justice,Justice,Card,정의,1
+533,The Hermit,The Hermit,Card,은둔자,1
+534,Wheel of Fortune,Wheel of Fortune,Card,운명의 수레바퀴,1
+535,Strength,Strength,Card,힘,1
+536,The Hanged Man,The Hanged Man,Card,매달린 남자,1
+537,Death,Death,Card,죽음,1
+538,Temperance,Temperance,Card,절제,1
+539,The Devil,The Devil,Card,악마,1
+540,The Tower,The Tower,Card,탑,1
+541,The Stars,The Stars,Card,별,1
 542,The Sun and the Moon,The Sun and the Moon,,,1
-543,Judgement,Judgement,Item,심판,1
-544,The World,The World,Item,세계,1
+543,Judgement,Judgement,Card,심판,1
+544,The World,The World,Card,세계,1
 545,Old Capacitor,Old Capacitor,Trinket,오래된 축전기,1
 546,Brimstone Bombs,Brimstone Bombs,Item,유황불 폭탄,1
 547,Mega Mush,Mega Mush,Item,거대버섯,1
@@ -600,7 +600,7 @@
 599,Lemegeton,Lemegeton,Item,마도서 레메게톤,1
 600,Anima Sola,Anima Sola,Item,아니마 솔라,1
 601,Mega Chest,Mega Chest,Item,,1
-602,Queen of Hearts,Queen of Hearts,Item,하트 Q,1
+602,Queen of Hearts,Queen of Hearts,Card,하트 Q,1
 603,Gold Pill,Gold Pill,Item,,1
 604,Black Sack,Black Sack,Item,,1
 605,Charming Poop,Charming Poop,Item,,1
@@ -608,7 +608,7 @@
 607,Crane Game,Crane Game,Item,,1
 608,Hell Game,Hell Game,Item,,1
 609,Wooden Chest,Wooden Chest,Item,,1
-610,Wild Card,Wild Card,Item,와일드 카드,1
+610,Wild Card,Wild Card,Card,와일드 카드,1
 611,Haunted Chest,Haunted Chest,Item,,1
 612,Fool's Gold,Fool's Gold,,,1
 613,Golden Penny,Golden Penny,,,1
@@ -616,23 +616,23 @@
 615,Golden Battery,Golden Battery,Item,,1
 616,Confessional,Confessional,,,1
 617,Golden Trinket,Golden Trinket,Item,,1
-618,Soul of Isaac,Soul of Isaac,Item,아이작의 영혼,1
-619,Soul of Magdalene,Soul of Magdalene,Item,막달레나의 영혼,1
-620,Soul of Cain,Soul of Cain,Item,카인의 영혼,1
-621,Soul of Judas,Soul of Judas,Item,유다의 영혼,1
-622,Soul of???,Soul of ???,Item,???,1
-623,Soul of Eve,Soul of Eve,Item,이브의 영혼,1
-624,Soul of Samson,Soul of Samson,Item,삼손의 영혼,1
-625,Soul of Azazel,Soul of Azazel,Item,아자젤의 영혼,1
-626,Soul of Lazarus,Soul of Lazarus,Item,나사로의 영혼,1
-627,Soul of Eden,Soul of Eden,Item,에덴의 영혼,1
-628,Soul of the Lost,Soul of the Lost,Item,로스트의 영혼,1
-629,Soul of Lilith,Soul of Lilith,Item,릴리스의 영혼,1
-630,Soul of the Keeper,Soul of the Keeper,Item,키퍼의 영혼,1
-631,Soul of Apollyon,Soul of Apollyon,Item,아폴리온의 영혼,1
-632,Soul of the Forgotten,Soul of the Forgotten,Item,포가튼의 영혼,1
-633,Soul of Bethany,Soul of Bethany,Item,베서니의 영혼,1
-634,Soul of Jacob and Esau,Soul of Jacob and Esau,Item,야곱과 에서의 영혼,1
+618,Soul of Isaac,Soul of Isaac,Soul,아이작의 영혼,1
+619,Soul of Magdalene,Soul of Magdalene,Soul,막달레나의 영혼,1
+620,Soul of Cain,Soul of Cain,Soul,카인의 영혼,1
+621,Soul of Judas,Soul of Judas,Soul,유다의 영혼,1
+622,Soul of???,Soul of ???,Soul,???의 영혼,1
+623,Soul of Eve,Soul of Eve,Soul,이브의 영혼,1
+624,Soul of Samson,Soul of Samson,Soul,삼손의 영혼,1
+625,Soul of Azazel,Soul of Azazel,Soul,아자젤의 영혼,1
+626,Soul of Lazarus,Soul of Lazarus,Soul,나사로의 영혼,1
+627,Soul of Eden,Soul of Eden,Soul,에덴의 영혼,1
+628,Soul of the Lost,Soul of the Lost,Soul,로스트의 영혼,1
+629,Soul of Lilith,Soul of Lilith,Soul,릴리스의 영혼,1
+630,Soul of the Keeper,Soul of the Keeper,Soul,키퍼의 영혼,1
+631,Soul of Apollyon,Soul of Apollyon,Soul,아폴리온의 영혼,1
+632,Soul of the Forgotten,Soul of the Forgotten,Soul,포가튼의 영혼,1
+633,Soul of Bethany,Soul of Bethany,Soul,베서니의 영혼,1
+634,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul,야곱과 에사우의 영혼,1
 635,A Strange Door,A Strange Door,,,1
 636,Death Certificate,Death Certificate,Item,사망 증명서,1
 637,Dead God,Dead God,,,1


### PR DESCRIPTION
## Summary
- add missing Korean translations for card and soul unlock names in `ui_secrets.csv`
- tag rune, card, and soul unlocks with dedicated Type values for easier filtering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d123e2263c833288ff486e1b804a73