### PR TITLE
Fix secret unlocking for extended secret range

### DIFF
--- a/gui_support.py
+++ b/gui_support.py
@@ -192,7 +192,8 @@ def unlockAllSecrets(*args):
         for arg in args:
             print ('    another arg:', arg)
         sys.stdout.flush()
-    global_info["data"] = script.updateSecrets(global_info["data"], [str(i) for i in range(1, 638)])
+    secret_count = script.getSecretCount(global_info["data"])
+    global_info["data"] = script.updateSecrets(global_info["data"], [str(i) for i in range(1, secret_count + 1)])
     saveFile()
     populateAllInfo()
 


### PR DESCRIPTION
## Summary
- compute the number of secrets dynamically from the save file so helper functions work with the full range
- update secret read/write helpers and example code to use the dynamic count
- call the new helper from the legacy GUI unlock-all action so it affects every secret

## Testing
- python -m compileall script.py gui_support.py isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d1b39f67748332846228b77b299ea5