### PR TITLE
Remove 'Rune of' prefix from rune entries

### DIFF
--- a/ui_secrets.csv
+++ b/ui_secrets.csv
@@ -87,14 +87,14 @@
 86,The Cellar,Alt stage to the basement.,Map,,1
 87,The Catacombs,Alt stage to the caves.,Map,,1
 88,The Necropolis,Alt stage to the depths.,Map,,1
-89,Rune of Hagalaz,Rune of Hagalaz,Rune,하갈라즈,1
-90,Rune of Jera,Rune of Jera,Rune,제라,1
-91,Rune of Ehwaz,Rune of Ehwaz,Rune,에와즈,1
-92,Rune of Dagaz,Rune of Dagaz,Rune,다가즈,1
-93,Rune of Ansuz,Rune of Ansuz,Rune,엔수즈,1
-94,Rune of Perthro,Rune of Perthro,Rune,페트로,1
-95,Rune of Berkano,Rune of Berkano,Rune,벨카노,1
-96,Rune of Algiz,Rune of Algiz,Rune,알기즈,1
+89,Hagalaz,Hagalaz,Rune,하갈라즈,1
+90,Jera,Jera,Rune,제라,1
+91,Ehwaz,Ehwaz,Rune,에와즈,1
+92,Dagaz,Dagaz,Rune,다가즈,1
+93,Ansuz,Ansuz,Rune,엔수즈,1
+94,Perthro,Perthro,Rune,페트로,1
+95,Berkano,Berkano,Rune,벨카노,1
+96,Algiz,Algiz,Rune,알기즈,1
 97,Chaos Card,Chaos Card,Card,혼돈 카드,1
 98,Credit Card,Credit Card,Card,신용카드,1
 99,Rules Card,Rules Card,Card,규칙 카드,1


### PR DESCRIPTION
## Summary
- remove the "Rune of" prefix from rune entries in `ui_secrets.csv` so only the rune names remain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2582d2cfc8332af9a86d4eb5dfd76