### PR TITLE
Make challenge tab helper text single-line

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -407,7 +407,6 @@ class IsaacSaveEditor(tk.Tk):
         ttk.Label(
             container,
             text="도전과제는 모두 해금하고, 다른 아이템 탭에서 해금여부를 변경하세요.",
-            wraplength=520,
             justify="left",
         ).grid(column=0, row=1, sticky="w", pady=(8, 0))
 


### PR DESCRIPTION
## Summary
- prevent the challenge tab helper note from wrapping, matching the achievement item tab layout

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d2589948948332bcb34596f6185d3e