### PR TITLE
Limit challenge tab instructions width

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -407,6 +407,7 @@ class IsaacSaveEditor(tk.Tk):
         ttk.Label(
             container,
             text="도전과제는 모두 해금하고, 다른 아이템 탭에서 해금여부를 변경하세요.",
+            wraplength=520,
             justify="left",
         ).grid(column=0, row=1, sticky="w", pady=(8, 0))
 


### PR DESCRIPTION
## Summary
- wrap the challenge tab instructions label to avoid excessive whitespace in the challenge description area

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a9dfda7c8332835a06fca2383dfe