### PR TITLE
Fix challenge tab description spacing

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -196,7 +196,7 @@ class IsaacSaveEditor(tk.Tk):
 
         challenge_tab = ttk.Frame(notebook, padding=12)
         challenge_tab.columnconfigure(0, weight=1)
-        challenge_tab.rowconfigure(1, weight=1)
+        challenge_tab.rowconfigure(2, weight=1)
         notebook.add(challenge_tab, text="도전과제")
         self._build_challenges_tab(challenge_tab)
 


### PR DESCRIPTION
## Summary
- adjust the challenge tab row configuration so the description label no longer stretches vertically

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d2ac499ca88332a391c64ba99bb9c2