### PR TITLE
Center auto overwrite help window

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -1599,6 +1599,18 @@ class IsaacSaveEditor(tk.Tk):
 
         help_window.bind("<Escape>", lambda event: help_window.destroy())
 
+        help_window.update_idletasks()
+        root_x = self.winfo_rootx()
+        root_y = self.winfo_rooty()
+        root_width = self.winfo_width()
+        root_height = self.winfo_height()
+        window_width = help_window.winfo_width()
+        window_height = help_window.winfo_height()
+
+        pos_x = root_x + (root_width - window_width) // 2
+        pos_y = root_y + (root_height - window_height) // 2
+        help_window.geometry(f"+{pos_x}+{pos_y}")
+
     def _apply_auto_999_if_needed(self) -> None:
         if not bool(self.auto_set_999_var.get()):
             return


### PR DESCRIPTION
## Summary
- center the auto overwrite help popup relative to the main application window
- update the help dialog placement after widgets are laid out so it appears centered on screen

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d3f51bbe748332823062e0b86433ad