### PR TITLE
Add challenge translations and sync secret unlocks

### DIFF
--- a/ui_challenges.csv
+++ b/ui_challenges.csv
@@ -1,46 +1,46 @@
 ﻿ChallengeID,ChallengeName,Korean,CompletedFlag
-1,Pitch Black,,1
-2,High Brow,,1
-3,Head Trauma,,1
-4,Darkness Falls,,1
-5,The Tank,,1
-6,Solar System,,1
+1,Pitch Black,칠흑같은 어둠,1
+2,High Brow,고상한 척,1
+3,Head Trauma,두부 외상,1
+4,Darkness Falls,어둠이 내려온다,1
+5,The Tank,탱크,1
+6,Solar System,태양계,1
 7,Suicide King,자살 왕,1
-8,Cat Got Your Tongue,,1
-9,Demo Man,,1
-10,Cursed!,,1
+8,Cat Got Your Tongue,혀를 고양이한테 빼앗겼나,1
+9,Demo Man,데모맨,1
+10,Cursed!,저주!,1
 11,Glass Cannon,유리 대포,1
-12,When Life Gives You Lemons,,1
-13,BEANS!,,1
-14,Its In The Cards,,1
-15,Slow Roll,,1
-16,Computer Savy,,1
-17,WAKA WAKA,,1
-18,The Host,,1
-19,The Family Man,,1
-20,Purist,,1
-21,XXXXXXXXL,,1
-22,SPEED!,,1
-23,Blue Bomber,,1
-24,PAY TO PLAY,,1
-25,Have A Heart,,1
-26,I RULE!,,1
-27,BRAINS!,,1
-28,PRIDE DAY!,,1
-29,Onan's Streak,,1
-30,The Guardian,,1
-31,Backasswards,,1
-32,Aprils Fool,,1
-33,Pokey Mans,,1
-34,Ultra Hard,,1
-35,Pong,,1
-36,Scat Man,,1
-37,Bloody Mary,,1
-38,Baptism by Fire,,1
-39,Isaac's Awakening,,1
-40,Seeing Double,,1
-41,Pica Run,,1
-42,Hot Potato,,1
-43,Cantripped!,,1
-44,Red Redemption,,1
-45,DELETE THIS,,1
+12,When Life Gives You Lemons,인생이 레몬을 준다면,1
+13,BEANS!,콩!,1
+14,Its In The Cards,카드에 적힌 운명,1
+15,Slow Roll,느린 굴림,1
+16,Computer Savy,컴퓨터 천재,1
+17,WAKA WAKA,와카 와카,1
+18,The Host,숙주,1
+19,The Family Man,패밀리맨,1
+20,Purist,순수주의자,1
+21,XXXXXXXXL,XXXXXXXXL,1
+22,SPEED!,스피드!,1
+23,Blue Bomber,블루 폭격기,1
+24,PAY TO PLAY,돈 내고 플레이,1
+25,Have A Heart,하트 좀 줘,1
+26,I RULE!,내가 왕이다!,1
+27,BRAINS!,브레인!,1
+28,PRIDE DAY!,프라이드 데이!,1
+29,Onan's Streak,오난의 연속,1
+30,The Guardian,수호자,1
+31,Backasswards,거꾸로 진행,1
+32,Aprils Fool,만우절,1
+33,Pokey Mans,포키 맨즈,1
+34,Ultra Hard,울트라 하드,1
+35,Pong,퐁,1
+36,Scat Man,스캣맨,1
+37,Bloody Mary,블러디 메리,1
+38,Baptism by Fire,불의 세례,1
+39,Isaac's Awakening,아이작의 각성,1
+40,Seeing Double,두 배로 보이기,1
+41,Pica Run,이상식증 질주,1
+42,Hot Potato,뜨거운 감자,1
+43,Cantripped!,캔트립!,1
+44,Red Redemption,붉은 속죄,1
+45,DELETE THIS,이걸 삭제해,1


### PR DESCRIPTION
## Summary
- add Korean translations for all challenge names in `ui_challenges.csv`
- extend secret loading to retain metadata and build links between secrets and challenges
- update unlock/lock handlers so toggling a secret also updates the matching challenges (and vice versa)

## Testing
- python -m py_compile isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d4009375d883328e0f8889f656d1db