### PR TITLE
Adjust Korean tab labels

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -143,7 +143,11 @@ class IsaacSaveEditor(tk.Tk):
         self, notebook: ttk.Notebook, tab_widget: tk.Widget, korean: str, english: str
     ) -> None:
         def updater() -> None:
-            notebook.tab(tab_widget, text=self._text(korean, english))
+            if self._english_ui_enabled:
+                text = english or korean or ""
+            else:
+                text = korean or english or ""
+            notebook.tab(tab_widget, text=text)
 
         self._register_language_binding(updater)
 


### PR DESCRIPTION
## Summary
- ensure tab labels display only the Korean text when the Korean UI is active
- preserve English tab labels when the English UI is selected

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d44189ce1083329f0cb554bd9a3c81