### PR TITLE
Remove English suffix from Korean UI labels

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -118,8 +118,6 @@ class IsaacSaveEditor(tk.Tk):
         korean = korean or english
         if self._english_ui_enabled:
             return english or ""
-        if english and korean and korean != english:
-            return f"{korean} ({english})"
         return korean or english or ""
 
     def _register_language_binding(self, callback: Callable[[], None]) -> None:


### PR DESCRIPTION
## Summary
- stop appending the English translation in parentheses when the Korean UI language is active by simplifying `_text`

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d443f470648332ae34b61472ac9cd1