### PR TITLE
Adjust icon spacing for item icons

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -75,7 +75,7 @@ class SecretIcon:
 class IconCheckboxTreeview(CheckboxTreeview):
     """Checkbox treeview that can display custom icons alongside checkboxes."""
 
-    _ICON_SPACING = 4
+    _ICON_SPACING = 32
     _STYLE_NAME = "IconCheckboxTreeview.Treeview"
     _ROW_PADDING = 6
 


### PR DESCRIPTION
## Summary
- set the icon spacing in `IconCheckboxTreeview` to 32px so only passive, active, and trinket categories with icons get the wider gap while others remain unchanged

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d5276cfb248332b028805fd75f9c53