### PR TITLE
Add language selector and highlight toggle

### DIFF
--- a/ui_secrets.csv
+++ b/ui_secrets.csv
@@ -1,641 +1,641 @@
-﻿SecretID,SecretName,UnlockName,Type,Korean,UnlockedFlag
-1,Magdalene,Magdalene,Character,막달레나,1
-2,Cain,Cain,Character,카인,1
-3,Judas,Judas,Character,유다,1
-4,The Womb,Womb,Map,챕터4-자궁,1
-5,The Harbingers,The Harbingers,Boss,4기사 등장,1
-6,A Cube of Meat,Cube of Meat,Item,고기조각,1
-7,The Book of Revelations,Book of Revelations,Item,요한묵시록,1
-8,A Noose,Transcendence,Item,초월,1
-9,The Nail,The Nail,Item,대못,1
-10,A Quarter,A Quarter,Item,쿼터,1
-11,A Fetus in a Jar,Dr. Fetus,Item,태아 박사,1
-12,A Small Rock,The Small Rock,Item,작은 돌,1
-13,Monstro's Tooth,Monstro's Tooth,Item,몬스트로의 이빨,1
-14,Lil' Chubby,Little Chubby,Item,리틀 처비,1
-15,Loki's Horns,Loki's Horns,Item,로키의 뿔,1
-16,Something From The Future,Steven,Item,스티븐,1
-17,Something Cute,C.H.A.D.,Boss,,1
-18,Something Sticky,Gish,Boss,,1
-19,A Bandage,Super Bandage,Item,슈퍼 밴디지,1
-20,A Cross,The Relic,Item,성유물,1
-21,A Bag of Pennies,Sack of Pennies,Item,동전 주머니,1
-22,The Book of Sin,The Book of Sin,Item,죄악의 책,1
-23,Little Gish,Little Gish,Item,리틀 기쉬,1
-24,Little Steven,Little Steven,Item,리틀 스티븐,1
-25,Little C.H.A.D.,Little C.H.A.D.,Item,리틀 차드,1
-26,A Gamekid,The Gamekid,Item,게임키드,1
-27,A Halo,The Halo,Item,광륜,1
-28,Mr. Mega,Mr. Mega,Item,미스터 메가,1
-29,The D6,The D6,Item,주사위,1
-30,The Scissors,Scissors,Item,가위,1
-31,The Parasite,The Parasite,Item,기생충,1
-32,???,??? (Blue Baby),Character,???,1
-33,Everything Is Terrible!!!,Everything Is Terrible!!!,Other,"챔피언 등장, 대체 보스 출현, 저주 빈도 증가",1
-34,It Lives!,It Lives,Boss,,1
-35,Mom's Contact,Mom's Contacts,Item,엄마의 콘텍트렌즈,1
-36,The Necronomicon,The Necronomicon,Item,네크로노미콘,1
-37,Basement Boy,Basement Boy,None,,1
-38,Spelunker Boy,Spelunker Boy,None,,1
-39,Dark Boy,Dark Boy,None,,1
-40,Mama's Boy,Mama's Boy,None,,1
-41,Golden God!,Golden God!,None,,1
-42,Eve,Eve,Character,이브,1
-43,Mom's Knife,Mom's Knife,Item,엄마의 식칼,1
-44,The Razor,Razor Blade,Item,면도날,1
-45,Guardian Angel,Guardian Angel,Item,수호천사,1
-46,A Bag of Bombs,Bomb Bag,Item,폭탄 주머니,1
-47,Demon Baby,Demon Baby,Item,악마 아기,1
-48,Forget Me Now,Forget Me Now,Item,날 잊어 주세요,1
-49,The D20,D20,Item,20면 주사위,1
-50,Celtic Cross,Celtic Cross,Item,켈트 십자가,1
-51,Abel,Abel,Item,아벨,1
-52,Curved Horn,Curved Horn,Trinket,휘어진 뿔,1
-53,Sacrificial Dagger,Sacrificial Dagger,Item,희생의 단도,1
-54,Bloody Lust,Bloody Lust,Item,피의 욕망,1
-55,Blood Penny,Bloody Penny,Trinket,피 묻은 동전,1
-56,Blood Rights,Blood Rights,Item,피의 권리,1
-57,The Polaroid,The Polaroid,Item,즉석사진,1
-58,Dad's Key,Dad's Key,Item,아빠의 열쇠,1
-59,Blue Candle,The Candle,Item,양초,1
-60,Burnt Penny,Burnt Penny,Trinket,타버린 동전,1
-61,Lucky Toe,Lucky Toe,Trinket,행운의 발가락,1
-62,Epic Fetus,Epic Fetus,Item,쩌는 태아,1
-63,SMB Super Fan,SMB Super Fan,Item,슈미보 광팬,1
-64,Counterfeit Coin,Counterfeit Penny,Trinket,가짜 동전,1
-65,Guppy's Hairball,Guppy's Hairball,Item,구피의 털뭉치,1
-66,A Forgotten Horseman,Conquest,Boss,,1
-67,Samson,Samson,Character,삼손,1
-68,Something Icky,Triachnid,Boss,,1
-69,!Platinum God!,!Platinum God!,None,,1
-70,Isaac's Head,Isaac's Head,Trinket,아이작의 머리,1
-71,Maggy's Faith,Maggy's Faith,Trinket,매기의 믿음,1
-72,Judas' Tongue,Judas' Tongue,Trinket,유다의 혀,1
-73,???'s Soul,???'s Soul,Trinket,???의 영혼,1
-74,Samson's Lock,Samson's Lock,Trinket,삼손의 머리채,1
-75,Cain's Eye,Cain's Eye,Trinket,카인의 오른쪽 눈,1
-76,Eve's Bird Foot,Eve's Bird Foot,Trinket,이브의 새 다리,1
-77,The Left Hand,The Left Hand,Trinket,왼손목,1
-78,The Negative,The Negative,Item,반전사진,1
-79,Azazel,Azazel,Character,아자젤,1
-80,Lazarus,Lazarus,Character,나사로,1
-81,Eden,Eden,Character,에덴,1
-82,The Lost,The Lost,Character,로스트,1
-83,Dead Boy,Dead Boy,None,,1
-84,The Real Platinum God,The Real Platinum God,None,,1
-85,Lucky Rock,Lucky Rock,Trinket,행운의 돌조각,1
-86,The Cellar,Alt stage to the basement.,Map,,1
-87,The Catacombs,Alt stage to the caves.,Map,,1
-88,The Necropolis,Alt stage to the depths.,Map,,1
-89,Hagalaz,Hagalaz,Rune,하갈라즈,1
-90,Jera,Jera,Rune,제라,1
-91,Ehwaz,Ehwaz,Rune,에와즈,1
-92,Dagaz,Dagaz,Rune,다가즈,1
-93,Ansuz,Ansuz,Rune,엔수즈,1
-94,Perthro,Perthro,Rune,페트로,1
-95,Berkano,Berkano,Rune,벨카노,1
-96,Algiz,Algiz,Rune,알기즈,1
-97,Chaos Card,Chaos Card,Card,혼돈 카드,1
-98,Credit Card,Credit Card,Card,신용카드,1
-99,Rules Card,Rules Card,Card,규칙 카드,1
-100,Card Against Humanity,A Card Against Humanity,Card,비인간적인 카드,1
-101,Swallowed Penny,Swallowed Penny,Trinket,삼킨 동전,1
-102,Robo-Baby 2.0,Robo-Baby 2.0,Item,로보 아기 2.0,1
-103,Death's Touch,Death's Touch,Item,죽음의 손길,1
-104,Technology .5,Tech.5,Item,기계 0.5,1
-105,Missing No.,Missing No.,Item,Missing No.,1
-106,Isaac's Tears,Isaac's Tears,Item,아이작의 눈물,1
-107,Guillotine,Guillotine,Item,단두대,1
-108,Judas' Shadow,Judas' Shadow,Item,유다의 그림자,1
-109,Maggy's Bow,Maggy's Bow,Item,매기의 리본,1
-110,Cain's Other Eye,Cain's Other Eye,Item,카인의 왼쪽 눈,1
-111,Black Lipstick,Black Lipstick,Trinket,검은 립스틱,1
-112,Eve's Mascara,Eve's Mascara,Item,이브의 마스카라,1
-113,Fate,Fate,Item,운명,1
-114,???'s Only Friend,???'s Only Friend,Item,???의 하나뿐인 친구,1
-115,Samson's Chains,Samson's Chains,Item,삼손의 쇠사슬,1
-116,Lazarus' Rags,Lazarus' Rags,Item,나사로의 붕대,1
-117,Broken Ankh,Broken Ankh,Trinket,부서진 앙크,1
-118,Store Credit,Store Credit,Trinket,상점 상품권,1
-119,Pandora's Box,Pandora's Box,Item,판도라의 상자,1
-120,Suicide King,Suicide King,Card,자살 왕,1
-121,Blank Card,Blank Card,Item,빈 카드,1
-122,Book of Secrets,Book of Secrets,Item,비밀의 책,1
-123,Mysterious Paper,Mysterious Paper,Trinket,신비한 종이,1
-124,Mystery Sack,Mystery Sack,Item,수수께끼의 주머니,1
-125,Undefined,Undefined,Item,Undefined,1
-126,Satanic Bible,Satanic Bible,Item,사탄경,1
-127,Daemon's Tail,Daemon's Tail,Trinket,악마 꼬리,1
-128,Abaddon,Abaddon,Item,아바돈,1
-129,Isaac's Heart,Isaac's Heart,Item,아이작의 심장,1
-130,The Mind,The Mind,Item,정신,1
-131,The Body,The Body,Item,육체,1
-132,The Soul,The Soul,Item,영혼,1
-133,The D100,D100,Item,100면 주사위,1
-134,Blue Map,Blue Map,Item,파란 지도,1
-135,There's Options,There's Options,Item,추가 선택권,1
-136,Black Candle,Black Candle,Item,검은 양초,1
-137,Red Candle,Red Candle,Item,빨간 양초,1
-138,Stop Watch,Stop Watch,Item,스톱워치,1
-139,Wire Coat Hanger,Wire Coat Hanger,Item,철제 옷걸이,1
-140,Ipecac,Ipecac,Item,구토제,1
-141,Experimental Treatment,Experimental Treatment,Item,임상시험,1
-142,Krampus,Krampus,Boss,크람푸스,1
-143,Head of Krampus,Head of Krampus,Item,크람푸스의 머리,1
-144,Super Meat Boy,Cube of Meat,Item,고기조각,1
-145,Butter Bean,Butter Bean,Item,흰강낭콩,1
-146,Little Baggy,Little Baggy,Item,작은 주머니,1
-147,Blood Bag,Blood Bag,Item,혈액 팩,1
-148,The D4,D4,Item,4면 주사위,1
-149,Missing Poster,Missing Poster,Trinket,실종 포스터,1
-150,Rubber Cement,Rubber Cement,Item,고무 접착제,1
-151,Store Upgrade lv.1,Store Upgrade lv.1,Other,상점 업그레이드 Lv.1,1
-152,Store Upgrade lv.2,Store Upgrade lv.2,Other,상점 업그레이드 Lv.2,1
-153,Store Upgrade lv.3,Store Upgrade lv.3,Other,상점 업그레이드 Lv.3,1
-154,Store Upgrade lv.4,Store Upgrade lv.4,Other,상점 업그레이드 Lv.4,1
-155,Angels,Angel,Boss,천사 석상 파괴가능,1
-156,Godhead,Godhead,Item,신,1
-157,Darkness Falls,Darkness Falls,None,챌린지4,1
-158,The Tank,The Tank,None,챌린지5,1
-159,Solar System,Solar System,None,챌린지6,1
-160,Suicide King,Suicide King (Challenge),None,챌린지7,1
-161,Cat Got Your Tongue,Cat Got Your Tongue,None,챌린지8,1
-162,Demo Man,Demo Man,None,챌린지9,1
-163,Cursed!,Cursed!,None,챌린지10,1
-164,Glass Cannon,Glass Cannon (Challenge),None,챌린지11,1
-165,The Family Man,The Family Man,None,챌린지19,1
-166,Purist,Purist,None,챌린지20,1
-167,Lost Baby,Lost Baby,Other,랜덤 패밀리어,1
-168,Cute Baby,Cute Baby,Other,랜덤 패밀리어,1
-169,Crow Baby,Crow Baby,Other,랜덤 패밀리어,1
-170,Shadow Baby,Shadow Baby,Other,랜덤 패밀리어,1
-171,Glass Baby,Glass Baby,Other,랜덤 패밀리어,1
-172,Wrapped Baby,Wrapped Baby,Other,랜덤 패밀리어,1
-173,Begotten Baby,Begotten Baby,Other,랜덤 패밀리어,1
-174,Dead Baby,Dead Baby,Other,랜덤 패밀리어,1
-175,#NAME?,#NAME?,Other,랜덤 패밀리어,1
-176,Glitch Baby,Glitch Baby,Other,랜덤 패밀리어,1
-177,Fighting Baby,Fighting Baby,Other,랜덤 패밀리어,1
-178,Lord of the Flies,Beelzebub,Other,Beelzebub 세트 해금,1
-179,Fart Baby,Farting Baby,Item,방귀쟁이 아기,1
-180,Purity,Purity,Item,순도,1
-181,D12,D12,Item,12면 주사위,1
-182,Betrayal,Betrayal,Item,배신,1
-183,Fate's Reward,Fate's Reward,Item,운명의 보상,1
-184,Athame,Athame,Item,마법 단검,1
-185,Blind Rage,Blind Rage,Trinket,눈먼 분노,1
-186,Maw of the Void,Maw Of The Void,Item,공허의 구렁텅이,1
-187,Empty Vessel,Empty Vessel,Item,빈 그릇,1
-188,Eden's Blessing,Eden's Blessing,Item,에덴의 축복,1
-189,Sworn Protector,Sworn Protector,Item,맹세한 수호자,1
-190,Incubus,Incubus,Item,인큐버스,1
-191,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Other,키퍼가 1코인을 가짐,1
-192,Lil' Chest,Lil Chest,Item,꼬마 상자,1
-193,Censer,Censer,Item,향로,1
-194,Evil Eye,Evil Eye,Item,악마의 눈,1
-195,My Shadow,My Shadow,Item,내 그림자,1
-196,Cracked Dice,Cracked Dice,Trinket,금이 간 주사위,1
-197,Black Feather,Black Feather,Trinket,검은 깃털,1
-198,Lusty Blood,Lusty Blood,Item,욕망의 피,1
-199,Lilith,Lilith,Character,릴리스,1
-200,Key Bum,Key Bum,Item,열쇠 거지,1
-201,GB Bug,GB Bug,Item,게임 버그,1
-202,Zodiac,Zodiac,Item,황도궁,1
-203,Box of Friends,Box of Friends,Item,친구 상자,1
-204,Rib of Greed,Rib of Greed,Trinket,그리드의 갈비뼈,1
-205,Cry Baby,Cry Baby,Other,랜덤 패밀리어,1
-206,Red Baby,Red Baby,Other,랜덤 패밀리어,1
-207,Green Baby,Green Baby,Other,랜덤 패밀리어,1
-208,Brown Baby,Brown Baby,Other,랜덤 패밀리어,1
-209,Blue Baby,Blue Baby,Other,랜덤 패밀리어,1
-210,Lil' Baby,Lil' Baby,Other,랜덤 패밀리어,1
-211,Rage Baby,Rage Baby,Other,랜덤 패밀리어,1
-212,Black Baby,Black Baby,Other,랜덤 패밀리어,1
-213,Long Baby,Long Baby,Other,랜덤 패밀리어,1
-214,Yellow Baby,Yellow Baby,Other,랜덤 패밀리어,1
-215,White Baby,White Baby,Other,랜덤 패밀리어,1
-216,Big Baby,Big Baby,Other,랜덤 패밀리어,1
-217,Noose Baby,Noose Baby,Other,랜덤 패밀리어,1
-218,Rune Bag,Rune Bag,Item,룬 가방,1
-219,Cambion Conception,Cambion Conception,Item,몽마의 자식들,1
-220,Serpent's Kiss,Serpent's Kiss,Item,독뱀의 키스,1
-221,Succubus,Succubus,Item,서큐버스,1
-222,Immaculate Conception,Immaculate Conception,Item,원죄없는 잉태,1
-223,Goat Head Baby,Goat Head Baby,Other,랜덤 패밀리어,1
-224,Gold Heart,Gold Heart,Pickup,황금 하트,1
-225,Get out of Jail Free Card,Get out of Jail Free Card,Card,감옥 탈출 카드,1
-226,Gold Bomb,Gold Bomb,Pickup,황금 폭탄,1
-227,2 new pills,"Percs!,Addicted!",Pill,"진통제!,과다복용!",1
-228,2 new pills,"Re-Lax,???(Amnesia)",Pill,"휴-식,건망증",1
-229,Poker Chip,Poker Chip,Trinket,포커 칩,1
-230,Stud Finder,Stud Finder,Trinket,벽체 탐지기,1
-231,D8,D8,Item,8면 주사위,1
-232,Kidney Stone,Kidney Stone,Item,신장 결석,1
-233,Blank Rune,Blank Rune (Achievement),Rune,비어있는 룬,1
-234,Blue Womb,Blue Womb(Hush),Map,허쉬 루트,1
-235,1001%,1001%,None,,1
-236,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Other,키퍼가 나무 동전을 가짐,1
-237,Keeper holds Store Key,Keeper holds Store Key,Other,키퍼가 상점 키를 가짐,1
-238,Deep Pockets,Deep Pockets,Item,넓은 가방,1
-239,Karma,Karma,Trinket,업보,1
-240,Sticky Nickels,Sticky nickel,Pickup,끈적이 니켈,1
-241,Super Greed Baby,Super Greed Baby,Other,랜덤 패밀리어,1
-242,Lucky Pennies,Lucky penny,Pickup,럭키 페니,1
-243,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Other,매달린 상점주인,1
-244,Wooden Nickel,Wooden Nickel,Item,나무 동전,1
-245,Cain holds Paperclip,Cain holds Paperclip,Other,카인이 종이 클립을 가짐,1
-246,Everything is Terrible 2!!!,Ultra Greed,Other,울트라 그리드 해금,1
-247,Special Shopkeepers,Special shopkeeper,Other,상점주인,1
-248,Eve now holds Razor Blade,Eve now holds Razor Blade,Other,이브가 면도날을 가짐,1
-249,Store Key,Store Key,Trinket,상점 열쇠,1
-250,Lost holds Holy Mantle,Lost holds Holy Mantle,Other,로스트가 홀리맨틀을 가짐,1
-251,Keeper,Keeper,Character,키퍼,1
-252,Hive Baby,Hive Baby,Other,랜덤 패밀리어,1
-253,Buddy Baby,Buddy Baby,Other,랜덤 패밀리어,1
-254,Colorful Baby,Colorful Baby,Other,랜덤 패밀리어,1
-255,Whore Baby,Whore Baby,Other,랜덤 패밀리어,1
-256,Cracked Baby,Cracked Baby,Other,랜덤 패밀리어,1
-257,Dripping Baby,Dripping Baby,Other,랜덤 패밀리어,1
-258,Blinding Baby,Blinding Baby,Other,랜덤 패밀리어,1
-259,Sucky Baby,Sucky Baby,Other,랜덤 패밀리어,1
-260,Dark Baby,Dark Baby,Other,랜덤 패밀리어,1
-261,Picky Baby,Picky Baby,Other,랜덤 패밀리어,1
-262,Revenge Baby,Revenge Baby,Other,랜덤 패밀리어,1
-263,Belial Baby,Belial Baby,Other,랜덤 패밀리어,1
-264,Sale Baby,Sale Baby,Other,랜덤 패밀리어,1
-265,XXXXXXXXL,XXXXXXXXL,None,챌린지 21,1
-266,SPEED!,SPEED!,None,챌린지 22,1
-267,Blue Bomber,Blue Bomber,None,챌린지 23,1
-268,PAY TO PLAY,PAY TO PLAY,None,챌린지 24,1
-269,Have a Heart,Have a Heart,None,챌린지 25,1
-270,I RULE!,I RULE!,None,챌린지 26,1
-271,BRAINS!,BRAINS!,None,챌린지 27,1
-272,PRIDE DAY!,PRIDE DAY!,None,챌린지 28,1
-273,Onan's Streak,Onan's Streak,None,챌린지 29,1
-274,The Guardian,The Guardian,None,챌린지 30,1
-275,Generosity,Generosity,None,,1
-276,Mega,Mega Blast,Item,메가 블래스트,1
-277,Backasswards,Backasswards,Other,챌린지 해금,1
-278,Aprils fool,Aprils Fool,Other,챌린지 해금,1
-279,Pokey Mans,Pokey Mans,Other,챌린지 해금,1
-280,Ultra Hard,Ultra Hard,Other,챌린지 해금,1
-281,PONG,Pong,Other,챌린지 해금,1
-282,D Infinity,D infinity,Item,무한 주사위,1
-283,Eucharist,Eucharist,Item,성찬,1
-284,Silver Dollar,Silver Dollar,Trinket,은화,1
-285,Shade,Shade,Item,셰이드,1
-286,King Baby,King Baby,Item,아기 왕,1
-287,Bloody Crown,Bloody Crown,Trinket,피투성이 왕관,1
-288,Dull Razor,Dull Razor,Item,무딘 면도칼,1
-289,Eden's Soul,Eden's Soul,Item,에덴의 영혼,1
-290,Dark Prince's Crown,Dark Prince's Crown,Item,어둠 왕자의 왕관,1
-291,Compound Fracture,Compound Fracture,Item,복합 골절,1
-292,Euthanasia,Euthanasia,Item,안락사,1
-293,Holy Card,Holy Card,Card,신성한 카드,1
-294,Crooked Penny,Crooked Penny,Item,구부러진 동전,1
-295,Void,Void,Item,공허,1
-296,D1,D1,Item,1면 주사위,1
-297,Glyph of Balance,Glyph of Balance,Item,균형의 문장,1
-298,Sack of Sacks,Sack of Sacks,Item,자루 주머니,1
-299,Eye of Belial,Eye of Belial,Item,벨리알의 눈,1
-300,Meconium,Meconium,Trinket,태변,1
-301,Stem Cell,Stem Cell,Trinket,줄기 세포,1
-302,Crow Heart,Crow Heart,Trinket,까마귀 심장,1
-303,Metronome,Metronome,Item,메트로놈,1
-304,Bat Wing,Bat Wing,Trinket,박쥐 날개,1
-305,Plan C,Plan C,Item,플랜 C,1
-306,Duality,Duality,Item,이중성,1
-307,Dad's Lost Coin,Dad's Lost Coin,Item,아빠의 잃어버린 동전,1
-308,Eye of Greed,Eye of Greed,Item,탐욕의 눈,1
-309,Black Rune,Black Rune,Rune,검은 룬,1
-310,Locust of Wrath,Locust of War,Trinket,전쟁의 메뚜기,1
-311,Locust of Pestilence,Locust of Pestilence,Trinket,역병의 메뚜기,1
-312,Locust of Famine,Locust of Famine,Trinket,기근의 메뚜기,1
-313,Locust of Death,Locust of Death,Trinket,죽음의 메뚜기,1
-314,Locust of Conquest,Locust of Conquest,Trinket,정복의 메뚜기,1
-315,Hushy,Hushy,Item,허쉬,1
-316,Brown Nugget,Brown Nugget,Item,갈색 너겟,1
-317,Mort Baby,Mort Baby,Other,랜덤 패밀리어,1
-318,Smelter,Smelter,Item,용광로,1
-319,Apollyon Baby,Apollyon Baby,Other,랜덤 패밀리어,1
-320,New Area,The Void,Map,공허,1
-321,Once More with Feeling!,Gulp!,Pill,꿀꺽!,1
-322,Hat trick!,Ace of Clubs,Card,클로버 A,1
-323,5 Nights at Mom's,Super special rock,Other,슈퍼색돌 등장,1
-324,Sin collector,Feels Like I'm Walking on Sunshine!,Pill,햇살 위를 걷는 기분이야!,1
-325,Dedication,Horf!,Pill,퉤엣!,1
-326,ZIP!,Ace of Diamonds,Card,다이아 A,1
-327,It's the Key,Ace of Spades,Card,스페이드 A,1
-328,Mr. Resetter!,Scared Heart,Pickup,도망가는 하트,1
-329,Living on the edge,Ace of Hearts,Card,하트 A,1
-330,U Broke It!,Vurp!,Pill,끄어억!,1
-331,Laz Bleeds More!,Laz Bleeds More!,Other,나사로가 빈혈증을 가짐,1
-332,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Other,막달레나가 체력회복 알약을 가짐,1
-333,Charged Key,Charged Key,Pickup,액티브 충전 열쇠,1
-334,Samson Feels Healthy!,Samson Feels Healthy!,Other,삼손이 피의 욕망을 가짐,1
-335,Greed's Gullet,Greed's Gullet,Item,탐욕의 식도,1
-336,The Marathon,Cracked Crown,Trinket,금이 간 왕관,1
-337,RERUN,RERUN,Other,재도전 모드 해금,1
-338,Delirious,Delirious,Item,정신착란,1
-339,1000000%,1000000%,None,,1
-340,Apollyon,Apollyon,Character,아폴리온,1
-341,Greedier!,Greedier Mode,Other,그리디어 모드 해금,1
-342,Burning Basement,Burning Basement,Map,불타는 지하실,1
-343,Flooded Caves,Flooded Caves,Map,,1
-344,Dank Depths,Dank Depths,Map,,1
-345,Scarred Womb,Scarred Womb,Map,,1
-346,Something wicked this way comes!,Little Horn,Boss,작은 뿔,1
-347,Something wicked this way comes+!,Big Horn,Boss,큰 뿔,1
-348,The gate is open!,Portal,Other,Portal 몬스터 해금(보이드 포탈),1
-349,Black Hole,Black Hole,Item,블랙홀,1
-350,Mystery Gift,Mystery Gift,Item,수수께끼의 선물,1
-351,Sprinkler,Sprinkler,Item,스프링클러,1
-352,Angry Fly,Angry Fly,Item,성난 파리,1
-353,Bozo,Bozo,Item,멍청이,1
-354,Broken Modem,Broken Modem,Item,고장난 모뎀,1
-355,Buddy in a Box,Buddy in a Box,Item,친구 든 상자,1
-356,Fast Bombs,Fast Bombs,Item,빠른 폭탄,1
-357,Lil Delirium,Lil Delirium,Item,꼬마 델리리움,1
-358,Hairpin,Hairpin,Trinket,머리핀,1
-359,Wooden Cross,Wooden Cross,Trinket,나무 십자가,1
-360,Butter!,Butter!,Trinket,버터!,1
-361,Huge Growth,Huge Growth,Card,거대한 성장,1
-362,Ancient Recall,Ancient Recall,Card,고대의 부름,1
-363,Era Walk,Era Walk,Card,시간 여행,1
-364,Coupon,Coupon,Item,쿠폰,1
-365,Telekinesis,Telekinesis,Item,염동력,1
-366,Moving Box,Moving Box,Item,수납상자,1
-367,Jumper Cables,Jumper Cables,Item,점퍼 케이블,1
-368,Leprosy,Leprosy,Item,문둥병,1
-369,Technology Zero,Technology Zero,Item,기계장치 0,1
-370,Filigree Feather,Filigree Feather,Trinket,세공 깃털,1
-371,Mr. ME!,Mr. ME!,Item,미 씨!,1
-372,7 Seals,7 Seals,Item,7개의 도장,1
-373,Angelic Prism,Angelic Prism,Item,천사빛 프리즘,1
-374,Pop!,Pop!,Item,뽁!,1
-375,Door Stop,Door Stop,Trinket,문 받침대,1
-376,Death's List,Death's List,Item,죽음의 살생부,1
-377,Haemolacria,Haemolacria,Item,피눈물병,1
-378,Lachryphagy,Lachryphagy,Item,눈물먹이,1
-379,Schoolbag,Schoolbag,Item,책가방,1
-380,Trisagion,Trisagion,Item,삼성송,1
-381,Extension Cord,Extension Cord,Trinket,연장 코드,1
-382,Flat Stone,Flat Stone,Item,납작한 돌,1
-383,Sacrificial Altar,Sacrificial Altar,Item,희생의 제단,1
-384,Lil Spewer,Lil Spewer,Item,꼬마 구토쟁이,1
-385,Blanket,Blanket,Item,담요,1
-386,Marbles,Marbles,Item,구슬,1
-387,Mystery Egg,Mystery Egg,Item,이상한 알,1
-388,Rotten Penny,Rotten Penny,Trinket,썩은 동전,1
-389,Baby-Bender,Baby-Bender,Trinket,아기 초능력자,1
-390,The Forgotten,The Forgotten,Character,포가튼,1
-391,Bone Heart,Bone Heart,Pickup,뼈하트,1
-392,Marrow,Marrow,Item,골수,1
-393,Slipped Rib,Slipped Rib,Item,빠진 갈비뼈,1
-394,Pointy Rib,Pointy Rib,Item,날카로운 갈비뼈,1
-395,Jaw Bone,Jaw Bone,Item,턱뼈,1
-396,Brittle Bones,Brittle Bones,Item,최약골,1
-397,Divorce Papers,Divorce Papers,Item,이혼 서류,1
-398,Hallowed Ground,Hallowed Ground,Item,성지,1
-399,Finger Bone,Finger Bone,Trinket,손가락 뼈,1
-400,Dad's Ring,Dad's Ring,Item,아빠의 반지,1
-401,Book of the Dead,Book of the Dead,Item,망자의 책,1
-402,Bone Baby,Bone Baby,Other,랜덤 패밀리어,1
-403,Bound Baby,Bound Baby,Other,랜덤 패밀리어,1
-404,Bethany,Bethany,Character,베서니,1
-405,Jacob and Esau,Jacob and Esau,Character,야곱과 에사우,1
-406,The Planetarium,Planetarium,Other,행성방 등장,1
-407,A Secret Exit,Downpour,Map,,1
-408,Forgotten Lullaby,Forgotten Lullaby,Trinket,잊혀진 자장가,1
-409,Fruity Plum,Fruity Plum,Item,탱탱한 플럼,1
-410,Plum Flute,Plum Flute,Item,플럼 피리,1
-411,Rotten Heart,Rotten Heart,Pickup,썩은 하트,1
-412,Dross,Dross,Map,,1
-413,Ashpit,Ashpit,Map,,1
-414,Gehenna,Gehenna,Map,,1
-415,Red Key,Red Key,Item,붉은 열쇠,1
-416,Wisp Baby,Wisp Baby,Other,랜덤 패밀리어,1
-417,Book of Virtues,Book of Virtues,Item,미덕의 책,1
-418,Urn of Souls,Urn of Souls,Item,영혼의 항아리,1
-419,Blessed Penny,Blessed Penny,Trinket,축복받은 동전,1
-420,Alabaster Box,Alabaster Box,Item,석고 옥합,1
-421,Beth's Faith,Beth's Faith,Trinket,베다니의 축복,1
-422,Soul Locket,Soul Locket,Item,영혼 로켓,1
-423,Divine Intervention,Divine Intervention,Item,신의 개입,1
-424,Vade Retro,Vade Retro,Item,사탄아 물렀거라,1
-425,Star of Bethlehem,Star of Bethlehem,Item,베들레헴의 별,1
-426,Hope Baby,Hope Baby,Other,랜덤 패밀리어,1
-427,Glowing Baby,Glowing Baby,Other,랜덤 패밀리어,1
-428,Double Baby,Double Baby,Other,랜덤 패밀리어,1
-429,The Stairway,The Stairway,Item,천국의 계단,1
-430,Red Stew,Red Stew,Item,붉은 스튜,1
-431,Birthright,Birthright,Item,생득권,1
-432,Damocles,Damocles,Item,다모클레스,1
-433,Rock Bottom,Rock Bottom,Item,밑바닥,1
-434,Inner Child,Inner Child,Item,내면의 아이,1
-435,Vanishing Twin,Vanishing Twin,Item,사라진 쌍둥이,1
-436,Genesis,Genesis,Item,창세기,1
-437,Suplex!,Suplex!,Item,수플렉스!,1
-438,Solomon's Baby,Solomon's Baby,Other,랜덤 패밀리어,1
-439,Illusion Baby,Illusion Baby,Other,랜덤 패밀리어,1
-440,Meat Cleaver,Meat Cleaver,Item,고기 도축칼,1
-441,Options?,Options?,Item,선택권?,1
-442,Yuck Heart,Yuck Heart,Item,역겨운 하트,1
-443,Candy Heart,Candy Heart,Item,캔디 하트,1
-444,Guppy's Eye,Guppy's Eye,Item,구피의 눈,1
-445,A Pound of Flesh,A Pound of Flesh,Item,살점 한 덩이,1
-446,Akeldama,Akeldama,Item,아겔다마,1
-447,Redemption,Redemption,Item,회개,1
-448,Eternal D6,Eternal D6,Item,이터널 주사위,1
-449,Montezuma's Revenge,Montezuma's Revenge,Item,몬테주마의 복수,1
-450,Bird Cage,Bird Cage,Item,새장,1
-451,Cracked Orb,Cracked Orb,Item,깨진 오브,1
-452,Bloody Gust,Bloody Gust,Item,피의 돌풍,1
-453,Empty Heart,Empty Heart,Item,비어있는 심장,1
-454,Devil's Crown,Devil's Crown,Trinket,악마의 왕관,1
-455,Lil Abaddon,Lil Abaddon,Item,꼬마 아바돈,1
-456,Tinytoma,Tinytoma,Item,타이니토마,1
-457,Astral Projection,Astral Projection,Item,유체이탈,1
-458,'M,'M,Trinket,,1
-459,Everything Jar,Everything Jar,Item,모든 게 담긴 병,1
-460,Lost Soul,Lost Soul,Item,잃어버린 영혼,1
-461,Hungry Soul,Hungry Soul,Item,굶주린 영혼,1
-462,Blood Puppy,Blood Puppy,Item,핏덩이 강아지,1
-463,C Section,C Section,Item,제왕절개,1
-464,Keeper's Sack,Keeper's Sack,Item,키퍼의 자루,1
-465,Keeper's Box,Keeper's Box,Item,키퍼의 상자,1
-466,Lil Portal,Lil Portal,Item,꼬마 포탈,1
-467,Worm Friend,Worm Friend,Item,지렁이 친구,1
-468,Bone Spurs,Bone Spurs,Item,골국,1
-469,Spirit Shackles,Spirit Shackles,Item,영혼의 족쇄,1
-470,Revelation,Revelation,Item,계시,1
-471,Jar of Wisps,Jar of Wisps,Item,도깨비불 든 병,1
-472,Magic Skin,Magic Skin,Item,마법의 피부,1
-473,Friend Finder,Friend Finder,Item,친구 찾기,1
-474,The Broken,Tainted Isaac,Character,더럽혀진 아이작,1
-475,The Dauntless,Tainted Magdalene,Character,더럽혀진 막달레나,1
-476,The Hoarder,Tainted Cain,Character,더럽혀진 카인,1
-477,The Deceiver,Tainted Judas,Character,더럽혀진 유다,1
-478,The Soiled,Tainted ???,Character,더럽혀진 ???,1
-479,The Curdled,Tainted Eve,Character,더럽혀진 이브,1
-480,The Savage,Tainted Samson,Character,더럽혀진 삼손,1
-481,The Benighted,Tainted Azazel,Character,더럽혀진 아자젤,1
-482,The Enigma,Tainted Lazarus,Character,더럽혀진 나사로,1
-483,The Capricious,Tainted Eden,Character,더럽혀진 에덴,1
-484,The Baleful,Tainted Lost,Character,더럽혀진 로스트,1
-485,The Harlot,Tainted Lilith,Character,더럽혀진 릴리스,1
-486,The Miser,Tainted Keeper,Character,더럽혀진 키퍼,1
-487,The Empty,Tainted Apollyon,Character,더럽혀진 아폴리온,1
-488,The Fettered,Tainted Forgotten,Character,더럽혀진 포가튼,1
-489,The Zealot,Tainted Bethany,Character,더럽혀진 베서니,1
-490,The Deserter,Tainted Jacob,Character,더럽혀진 야곱과 에사우,1
-491,Glitched Crown,Glitched Crown,Item,글리치 왕관,1
-492,Belly Jelly,Belly Jelly,Item,벨리 젤리,1
-493,Blue Key,Blue Key,Trinket,푸른 열쇠,1
-494,Sanguine Bond,Sanguine Bond,Item,핏빛 결속,1
-495,The Swarm,The Swarm,Item,파리 군단,1
-496,Heartbreak,Heartbreak,Item,비탄,1
-497,Larynx,Larynx,Item,후두,1
-498,Azazel's Rage,Azazel's Rage,Item,아자젤의 분노,1
-499,Salvation,Salvation,Item,구원,1
-500,TMTRAINER,TMTRAINER,Item,,1
-501,Sacred Orb,Sacred Orb,Item,성스러운 오브,1
-502,Twisted Pair,Twisted Pair,Item,뒤틀린 한 쌍,1
-503,Strawman,Strawman,Item,밀짚인형,1
-504,Echo Chamber,Echo Chamber,Item,반향효과,1
-505,Isaac's Tomb,Isaac's Tomb,Item,아이작의 무덤,1
-506,Vengeful Spirit,Vengeful Spirit,Item,복수심의 영혼,1
-507,Esau Jr.,Esau Jr.,Item,에사우 주니어,1
-508,Bloody Mary,Bloody Mary,None,unlock challenge,1
-509,Baptism by Fire,Baptism by Fire,None,unlock challenge,1
-510,Isaac's Awakening,Isaac's Awakening,None,unlock challenge,1
-511,Seeing Double,Seeing Double,None,unlock challenge,1
-512,Pica Run,Pica Run,None,unlock challenge,1
-513,Hot Potato,Hot Potato,None,unlock challenge,1
-514,Cantripped!,Cantripped!,None,unlock challenge,1
-515,Red Redemption,Red Redemption,None,unlock challenge,1
-516,DELETE THIS,DELETE THIS,None,,1
-517,Dirty Mind,Dirty Mind,Item,더러운 군집,1
-518,Sigil of Baphomet,Sigil of Baphomet,Trinket,바포메트의 인장,1
-519,Purgatory,Purgatory,Item,연옥,1
-520,Spirit Sword,Spirit Sword,Item,영혼검,1
-521,Broken Glasses,Broken Glasses,Trinket,깨진 안경,1
-522,Ice Cube,Ice Cube,Trinket,얼음 큐브,1
-523,Charged Penny,Charged Penny,Trinket,충전된 동전,1
-524,The Fool,The Fool?,Card,바보?,1
-525,The Magician,The Magician?,Card,마법사?,1
-526,The High Priestess,The High Priestess?,Card,여교황?,1
-527,The Empress,The Empress?,Card,여제?,1
-528,The Emperor,The Emperor?,Card,황제?,1
-529,The Hierophant,The Hierophant?,Card,교황?,1
-530,The Lovers,The Lovers?,Card,연인?,1
-531,The Chariot,The Chariot?,Card,전차?,1
-532,Justice,Justice?,Card,정의?,1
-533,The Hermit,The Hermit?,Card,은둔자?,1
-534,Wheel of Fortune,Wheel of Fortune?,Card,운명의 수레바퀴?,1
-535,Strength,Strength?,Card,힘?,1
-536,The Hanged Man,The Hanged Man?,Card,매달린 남자?,1
-537,Death,Death?,Card,죽음?,1
-538,Temperance,Temperance?,Card,절제?,1
-539,The Devil,The Devil?,Card,악마?,1
-540,The Tower,The Tower?,Card,탑?,1
-541,The Stars,The Stars?,Card,별?,1
-542,The Sun and the Moon,"The Sun?,the Moon?",Card,"해?,달?",1
-543,Judgement,Judgement?,Card,심판?,1
-544,The World,The World?,Card,세계?,1
-545,Old Capacitor,Old Capacitor,Trinket,오래된 축전기,1
-546,Brimstone Bombs,Brimstone Bombs,Item,유황불 폭탄,1
-547,Mega Mush,Mega Mush,Item,거대버섯,1
-548,Mom's Lock,Mom's Lock,Trinket,엄마의 머리뭉치,1
-549,Dice Bag,Dice Bag,Trinket,주사위 가방,1
-550,Holy Crown,Holy Crown,Trinket,신성한 왕관,1
-551,Mother's Kiss,Mother's Kiss,Trinket,어머니의 키스,1
-552,Gilded Key,Gilded Key,Trinket,도금 열쇠,1
-553,Lucky Sack,Lucky Sack,Trinket,복주머니,1
-554,Your Soul,Your Soul,Trinket,네 영혼,1
-555,Number Magnet,Number Magnet,Trinket,숫자 자석,1
-556,Dingle Berry,Dingle Berry,Trinket,딩글 베리,1
-557,Ring Cap,Ring Cap,Trinket,딱총 화약,1
-558,Strange Key,Strange Key,Trinket,이상한 열쇠,1
-559,Lil Clot,Lil Clot,Trinket,꼬마 클롯,1
-560,Temporary Tattoo,Temporary Tattoo,Trinket,스티커 문신,1
-561,Swallowed M80,Swallowed M80,Trinket,삼킨 M80,1
-562,Wicked Crown,Wicked Crown,Trinket,사악한 왕관,1
-563,Azazel's Stump,Azazel's Stump,Trinket,아자젤의 뿔대,1
-564,Torn Pocket,Torn Pocket,Trinket,찢어진 주머니,1
-565,Torn Card,Torn Card,Trinket,찢어진 카드,1
-566,Nuh Uh!,Nuh Uh!,Trinket,아니거든!,1
-567,Modeling Clay,Modeling Clay,Trinket,조형 찰흙,1
-568,Kid's Drawing,Kid's Drawing,Trinket,아이의 그림,1
-569,Crystal Key,Crystal Key,Trinket,수정 열쇠,1
-570,The Twins,The Twins,Trinket,쌍둥이,1
-571,Adoption Papers,Adoption Papers,Trinket,입양 서류,1
-572,Keeper's Bargain,Keeper's Bargain,Trinket,키퍼의 흥정,1
-573,Cursed Penny,Cursed Penny,Trinket,저주받은 동전,1
-574,Cricket Leg,Cricket Leg,Trinket,귀뚜라미 다리,1
-575,Apollyon's Best Friend,Apollyon's Best Friend,Trinket,아폴리온의 절친,1
-576,Polished Bone,Polished Bone,Trinket,연마한 뼈,1
-577,Hollow Heart,Hollow Heart,Trinket,텅 빈 심장,1
-578,Expansion Pack,Expansion Pack,Trinket,확장팩,1
-579,Beth's Essence,Beth's Essence,Trinket,베다니의 정수,1
-580,RC Remote,RC Remote,Trinket,RC 리모콘,1
-581,Found Soul,Found Soul,Trinket,되찾은 영혼,1
-582,Member Card,Member Card,Item,멤버쉽 카드,1
-583,Golden Razor,Golden Razor,Item,황금 면도날,1
-584,Spindown Dice,Spindown Dice,Item,스핀다운 주사위,1
-585,Hypercoagulation,Hypercoagulation,Item,과응고,1
-586,Bag of Crafting,Bag of Crafting,Item,조합 가방,1
-587,Dark Arts,Dark Arts,Item,흑마술,1
-588,IBS,IBS,Item,,1
-589,Sumptorium,Sumptorium,Item,섬토리움,1
-590,Berserk!,Berserk!,Item,폭주!,1
-591,Hemoptysis,Hemoptysis,Item,각혈,1
-592,Flip,Flip,Item,뒤집기,1
-593,Corrupted Data,Corrupted Data,Other,커럽티드 데이터(깨진 아이템),1
-594,Ghost Bombs,Ghost Bombs,Item,유령 폭탄,1
-595,Gello,Gello,Item,겔로,1
-596,Keeper's Kin,Keeper's Kin,Item,키퍼의 친척,1
-597,Abyss,Abyss,Item,무저갱,1
-598,Decap Attack,Decap Attack,Item,참수 공격,1
-599,Lemegeton,Lemegeton,Item,마도서 레메게톤,1
-600,Anima Sola,Anima Sola,Item,아니마 솔라,1
-601,Mega Chest,Mega Chest,Pickup,메가 상자,1
-602,Queen of Hearts,Queen of Hearts,Card,하트 퀸,1
-603,Gold Pill,Gold Pill,Pickup,황금 알약,1
-604,Black Sack,Black Sack,Pickup,검은 보따리,1
-605,Charming Poop,Charming Poop,Other,패밀리어 소환하는 똥,1
-606,Horse Pill,Horse Pill,Pill,말약,1
-607,Crane Game,Crane Game,Other,크레인 게임,1
-608,Hell Game,Hell Game,Other,악마 야바위꾼,1
-609,Wooden Chest,Wooden Chest,Pickup,나무 상자,1
-610,Wild Card,Wild Card,Card,와일드 카드,1
-611,Haunted Chest,Haunted Chest,Pickup,유령 상자,1
-612,Fool's Gold,Fool's Gold,Other,돈 박힌 돌,1
-613,Golden Penny,Golden Penny,Pickup,골든 페니,1
-614,Rotten Beggar,Rotten Beggar,Other,썩은 거지,1
-615,Golden Battery,Golden Battery,Pickup,황금 배터리(데미지입는거),1
-616,Confessional,Confessional,Other,고해실,1
-617,Golden Trinket,Golden Trinket,Other,황금 장신구 등장,1
-618,Soul of Isaac,Soul of Isaac,Rune,아이작의 영혼,1
-619,Soul of Magdalene,Soul of Magdalene,Rune,막달레나의 영혼,1
-620,Soul of Cain,Soul of Cain,Rune,카인의 영혼,1
-621,Soul of Judas,Soul of Judas,Rune,유다의 영혼,1
-622,Soul of???,Soul of ???,Rune,???의 영혼,1
-623,Soul of Eve,Soul of Eve,Rune,이브의 영혼,1
-624,Soul of Samson,Soul of Samson,Rune,삼손의 영혼,1
-625,Soul of Azazel,Soul of Azazel,Rune,아자젤의 영혼,1
-626,Soul of Lazarus,Soul of Lazarus,Rune,나사로의 영혼,1
-627,Soul of Eden,Soul of Eden,Rune,에덴의 영혼,1
-628,Soul of the Lost,Soul of the Lost,Rune,로스트의 영혼,1
-629,Soul of Lilith,Soul of Lilith,Rune,릴리스의 영혼,1
-630,Soul of the Keeper,Soul of the Keeper,Rune,키퍼의 영혼,1
-631,Soul of Apollyon,Soul of Apollyon,Rune,아폴리온의 영혼,1
-632,Soul of the Forgotten,Soul of the Forgotten,Rune,포가튼의 영혼,1
-633,Soul of Bethany,Soul of Bethany,Rune,베서니의 영혼,1
-634,Soul of Jacob and Esau,Soul of Jacob and Esau,Rune,야곱과 에사우의 영혼,1
-635,A Strange Door,A Strange Door,Map,비스트 루트로 가는 문,1
-636,Death Certificate,Death Certificate,Item,사망 증명서,1
-637,Dead God,Dead God,None,,1
-638,Play Online,Play Online,None,,1
-639,Win Online,Win Online,None,,1
-640,Win Online Daily,Win Online Daily,None,,1
+﻿SecretID,SecretName,UnlockName,Type,Korean,bul,cs_cz,de,el_gr,en_us,fr,it,ja_jp,nl_nl,pl,pt,pt_br,ro_ro,ru,spa,tr_tr,uk_ua,vi,zh_cn,UnlockedFlag
+1,Magdalene,Magdalene,Character,막달레나,Magdalene,Magdalene,Magdalene,Magdalene,Magdalene,Marie,Magdalene,Magdalene,Magdalene,Magdalena,Magdalene,Magdalene,Magdalene,Magdalene,Magdalena,Magdalene,Magdalene,Magdalene,Magdalene,1
+2,Cain,Cain,Character,카인,Cain,Cain,Cain,Cain,Cain,Caïn,Cain,Cain,Cain,Kain,Cain,Cain,Cain,Cain,Caín,Cain,Cain,Cain,Cain,1
+3,Judas,Judas,Character,유다,Judas,Judas,Judas,Judas,Judas,Judas,Judas,Judas,Judas,Judasz,Judas,Judas,Judas,Judas,Judas,Judas,Judas,Judas,Judas,1
+4,The Womb,Womb,Map,챕터4-자궁,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,Womb,1
+5,The Harbingers,The Harbingers,Boss,4기사 등장,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,The Harbingers,1
+6,A Cube of Meat,Cube of Meat,Item,고기조각,Куб от месо,XVII - Hvězda?,XVII - Die Sterne?,Κύβος κρέατος,Cube of Meat,Cube de Viande,Cubo di Carne,XVII - 星？,Kubus van vlees,Kostka Mięsa,Cube of Meat,Cube of Meat,Un Cub de Carne,XVII - Звёзды?,Cubo de carne,XVII - Yıldızlar?,Кубик м'яса,XVII - The Stars?,肉块,1
+7,The Book of Revelations,Book of Revelations,Item,요한묵시록,Книга на откровенията,Kniha Zjevení,Buch der Offenbarung,Βιβλίο των Αποκαλύψεων,Book of Revelations,Livre de la Révélation,Libro dell'Apocalisse,ヨハネの黙示録,Boek van Openbaringen,Księga Objawień,Book of Revelations,Book of Revelations,Cartea Revelațiilor,Книга Откровений,Libro de Revelaciones,Kırık Anahtar,Книга Одкровень,Book of Revelations,启示录,1
+8,A Noose,Transcendence,Item,초월,Възнасяне,XIX - Slunce,XIX - Die Sonne,Υπέρβαση,Transcendence,Transcendance,Trascendenza,XIX - 太陽,Transcendentie,Transcendencja,Transcendence,Transcendence,Transcendență,Энергия на 48 часов,Trascendencia,48 Saatlik Enerji!,Трансцендентність,XIX - The Sun,超凡升天,1
+9,The Nail,The Nail,Item,대못,Пиронът,Hřebík,Der Nagel,Το Καρφί,The Nail,Clou Pointu,Il Chiodo,釘,The spijker,Gwóźdź,The Nail,The Nail,Cuiul,Гвоздь,El clavo,Çivi,Цвях,The Nail,钉子,1
+10,A Quarter,A Quarter,Item,쿼터,Монета от 25 стотинки,XVIII - Měsíc?,XVIII - Der Mond?,Εικοσιπεντάρα,A Quarter,Une Petite Pièce,Un Quarto,XVIII - 月？,Een Kwart,Ćwierćdolarówka,A Quarter,A Quarter,Un Sfert,XVIII - Луна?,Un cuarto,XVIII - Ay?,Четвертак,XVIII - The Moon?,25美分,1
+11,A Fetus in a Jar,Dr. Fetus,Item,태아 박사,Д-р Ембрион,Dr. Zárodek,Doktor Fetus,Δρ. Έμβρυο,Dr. Fetus,Dr. Fœtus,Dr. Fetus,Dr. フィータス,Dr. Foetus,Dr. Fetus,Dr. Fetus,Dr. Fetus,Dr. Făt,Доктор Зародыш,Dr. Fetus,Dr. Fetüs,Доктор Зародок,Dr. Fetus,胎儿博士,1
+12,A Small Rock,The Small Rock,Item,작은 돌,Малкият камък,Edenova Duše,Seele von Eden,Η Μικρή Πέτρα,The Small Rock,Gros Caillou,La Pietruzza,エデンのソウル,De kleine rots,Kamyczek,The Small Rock,The Small Rock,Mica Piatră,Душа Эдема,La Roca pequeña,Edenin Ruhu,Маленький камінь,Soul of Eden,小石头,1
+13,Monstro's Tooth,Monstro's Tooth,Item,몬스트로의 이빨,Зъбът на Монстро,Evina Duše,Seele von Eva,Το Δόντι του Μονστρο,Monstro's Tooth,Dent de Monstro,Dente di Monstro,イブのソウル,Monstro's Tand,Ząb Monstro,Monstro's Tooth,Monstro's Tooth,Dintele lui Monstro,Душа Евы,Diente de Monstro,Evein Ruhu,Зуб Монстро,Soul of Eve,萌死戳的牙,1
+14,Lil' Chubby,Little Chubby,Item,리틀 처비,Малкият Чъби,Azazelova Duše,Seele von Azazel,Μικρός Τσάμπι,Little Chubby,P'tit Dodu,Cicciottella,アザゼルのソウル,Beetje Mollig,Mały Chubby,Little Chubby,Little Chubby,Micul Dolofan,Душа Азазеля,Pequeño Chubby,Azazelin Ruhu,Маленький Чаббі,Soul of Azazel,小胖蛆,1
+15,Loki's Horns,Loki's Horns,Item,로키의 뿔,Рогата на Локи,Lokiho Rohy,Lokis Hörner,Τα Κέρατα του Λόκι,Loki's Horns,Cornes de Loki,Corna di Loki,ロキのツノ,Loki's Hoorns,Rogi Loki'ego,Loki's Horns,Loki's Horns,Coarnele lui Loki,Рога Локи,Cuernos de Loki,Samsonın Ruhu,Ріжки Локі,Loki's Horns,洛基的角,1
+16,Something From The Future,Steven,Item,스티븐,Стивън,Spálená Mince,Verbrannte Münze,Στίβεν,Steven,Steven,Steven,燃え尽きたペニー,Steven,Steven,Steven,Steven,Steven,Сгоревший пенни,Steven,Yanık Para,Стівен,Burnt Penny,史蒂文,1
+17,Something Cute,C.H.A.D.,Boss,,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,C.H.A.D.,1
+18,Something Sticky,Gish,Boss,,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,Gish,1
+19,A Bandage,Super Bandage,Item,슈퍼 밴디지,Супер лепенка,Popraskaná Koruna,Rissige Krone,Υπερεπίδεσμος,Super Bandage,Super Pansement,Super Cerotto,ひびが入った冠,Super Verband,Super Bandaż,Super Bandage,Super Bandage,Super Bandajul,Треснувшая корона,Súper Vendaje,Çatlak Taç,Супер пластир,Cracked Crown,超级绷带,1
+20,A Cross,The Relic,Item,성유물,Реликвата,Relikvie,Die Reliquie,Το Λείψανο,The Relic,Relique,La Reliquia,遺物,Het Relikwie,Relikt,The Relic,The Relic,Relicva,Реликвия,La Reliquia,Kalıntı,Реліквія,The Relic,圣遗物,1
+21,A Bag of Pennies,Sack of Pennies,Item,동전 주머니,Кесия с монети,Apollyónova Duše,Seele von Apollyon,Σάκος Λεπτών,Sack of Pennies,Bourse,Sacco di Penny,アポリオンのソウル,Zak van Centen,Sakiewa z Monetami,Sack of Pennies,Sack of Pennies,Sac de Bănuți,Душа Аполлиона,Bolsa de centavos,Apollyonun Ruhu,Мішок пенні,Soul of Apollyon,硬币袋,1
+22,The Book of Sin,The Book of Sin,Item,죄악의 책,Книгата на греховете,Mandle,Seele von Jacob und Esau,Το Βιβλίο των Αμαρτιών,The Book of Sin,Amygdale,Tonsilla,ヤコブとエサウのソウル,Het Boek van Zonde,Księga Grzechu,The Book of Sin,The Book of Sin,Cartea Păcatului,Душа Иакова и Исава,Amígdala,Jacob and Esaunun Ruhu,Книга Гріхів,Soul of Jacob and Esau,七原罪之书,1
+23,Little Gish,Little Gish,Item,리틀 기쉬,Малък Гиш,Malý Gish,Kleiner Gish,Μικρός Γκις,Little Gish,P'tit Gish,Piccolo Gish,リトル ギッシュ,Kleine Gish,Mały Gish,Little Gish,Little Gish,Micul Gish,Маленький Гиш,Pequeño Gish,Küçük Gish,Маленький Гіш,Little Gish,吉什宝宝,1
+24,Little Steven,Little Steven,Item,리틀 스티븐,Малък Стивън,Malý Steven,Kleiner Steven,Μικρός Στίβεν,Little Steven,P'tit Steven,Piccolo Steven,リトル スティーブン,Kleine Steven,Mały Steven,Little Steven,Little Steven,Micul Steven,Маленький Стивен,Pequeño Steven,Küçük Mesut,Маленький Стівен,Little Steven,史蒂文宝宝,1
+25,Little C.H.A.D.,Little C.H.A.D.,Item,리틀 차드,Малък Ч.А.Д.,Červ Ouroboros,Ouroboros-Wurm,Μικρός C.H.A.D.,Little C.H.A.D.,P'tit C.H.A.D,Piccola C.H.A.D.,ウロボロスワーム,Kleine C.H.A.D.,Mały C.H.A.D.,Little C.H.A.D.,Little C.H.A.D.,Micul C.H.A.D.,Червь Уроборос,Pequeño C.H.A.D.,Ouroboros Solucanı,Маленький Ч.А.Д.,Ouroboros Worm,查德宝宝,1
+26,A Gamekid,The Gamekid,Item,게임키드,Геймкид,Použitá Plenka,Seele von Keeper,Το Gamekid,The Gamekid,Couche Usagée,Pannolino Usato,キーパーのソウル,De gamekid,Gamekid,The Gamekid,The Gamekid,Gamekid-ul,Душа Хранителя,Pañal usado,the Keeperın Ruhu,Геймкід,Soul of the Keeper,游戏掌机,1
+27,A Halo,The Halo,Item,광륜,Ореолът,Svatozář,Der Heiligenschein,The Halo,The Halo,Auréole,L'Aureola,ヘイロー,De Halo,Aureola,The Halo,The Halo,Aureola,Нимб,El Halo,Hale,Німб,The Halo,光环,1
+28,Mr. Mega,Mr. Mega,Item,미스터 메가,Мистър Мега,Pan Mega,Herr Mega,Κύριος Μέγα,Mr. Mega,M. Méga,Mr. Mega,ミスターメガ,Mr. Mega,Pan Mega,Mr. Mega,Mr. Mega,Dl. Mega,Мистер Мега,Sr. Mega,Bay Mega,Містер Мега,Mr. Mega,大爆弹先生,1
+29,The D6,The D6,Item,주사위,D6,Oběd v Sáčku,Lunchpaket,Εξάπλευρο Ζάρι,The D6,Sac de Friandises,Sacchetto per il Pranzo,弁当袋,De D6,D6,The D6,The D6,D6-le,Пакет с обедом,Bolsa del almuerzo,D6,D6,Bag Lunch,六面骰,1
+30,The Scissors,Scissors,Item,가위,Ножици,Nůžky,Scissors,Ψαλίδια,Scissors,Paire de Ciseaux,Forbici,ハサミ,Scissors,Nożyczki,Scissors,Scissors,Scissors,Ножницы,Tijeras,Makas,Ножиці,Scissors,剪刀,1
+31,The Parasite,The Parasite,Item,기생충,Паразитът,Kost Přání,Wunschknochen,Το Παράσιτο,The Parasite,Os de Poulet,Osso dei Desideri,ウィッシュボーン,De parasiet,Pasożyt,The Parasite,The Parasite,Parazitul,Кость желаний,Hueso de los deseos,Parazit,Паразит,Wish Bone,寄生虫,1
+32,???,??? (Blue Baby),Character,???,??? (Blue Baby),"Nemůže mít červené srdce#{{SoulHeart}} Zvýšení zdraví mu dává Duševní srdce#{{DevilRoom}} Ďábelské Dohody, které by stály 1 nebo 2 červené srdce, budou teď stát 1 nebo 2 duševní srdce#Zničení hovna vytvoří 1 modrou mušku",???,??? (Blue Baby),??? (Blue Baby),Ne peut pas avoir de cœurs rouges,Non può avere Cuori Rossi#{{SoulHeart}} Gli aumenti di salute conferiscono Cuori Celesti,赤ハートを持てない#体力が増える効果は、 代わりに青ハート+1#悪魔取引のコストは、 赤ハート1個=青1個、 赤ハート2個=青2個に、 それぞれ置き換わる#うんちを壊した時、 青ハエが1匹スポーン,??? (Blue Baby),???,??? (Blue Baby),???,Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts,???,No puede tener corazones rojos#{{SoulHeart}} los Objetos de vida otorgan Corazones de Alma,???,???,Không thể có Trái tim đỏ#{{SoulHeart}} Tăng máu tặng Trái tim hồn#{{DevilRoom}} Giao kèo quỷ tốn 1 hoặc 2 Trái tim đỏ sẽ tốn 1 hoặc 2 Trái tim hồn thay vì vậy#Phá phân tạo 1 ruồi xanh,不能拥有红心#{{SoulHeart}} 体力上升改为获得魂心,1
+33,Everything Is Terrible!!!,Everything Is Terrible!!!,Other,"챔피언 등장, 대체 보스 출현, 저주 빈도 증가",Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,Everything Is Terrible!!!,1
+34,It Lives!,It Lives,Boss,,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,It Lives,1
+35,Mom's Contact,Mom's Contacts,Item,엄마의 콘텍트렌즈,Лещите на мама,Mámina Kontaktní Čočka,Mamas Kontakte,Η Επαφή της Μαμάς,Mom's Contacts,Lentille de Maman,Lentine di Mamma,ママのコンタクト,Mama's Lenzen,Soczewki Mamy,Mom's Contacts,Mom's Contacts,Contactele Mamei,Мамины линзы,Lentillas de Mamá,Annenin Lensleri,Матусині лінзи,Mom's Contacts,妈妈的美瞳,1
+36,The Necronomicon,The Necronomicon,Item,네크로노미콘,Некрономикон,Zamoření?,Infested?,Το Νεκρονομικόν,The Necronomicon,Necronomicon,Il Necronomicon,感染症？,De Necronomicon,Nekronomikon,The Necronomicon,The Necronomicon,The Necronomicon,Зараженный?,El Necronomicón,Enfeksiyonlandın?,Некрономікон,Infested?,死灵之书,1
+37,Basement Boy,Basement Boy,None,,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,Basement Boy,1
+38,Spelunker Boy,Spelunker Boy,None,,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,Spelunker Boy,1
+39,Dark Boy,Dark Boy,None,,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,Dark Boy,1
+40,Mama's Boy,Mama's Boy,None,,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,Mama's Boy,1
+41,Golden God!,Golden God!,None,,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,Golden God!,1
+42,Eve,Eve,Character,이브,Eve,Eve,Eve,Eve,Eve,Ève,Eve,Eve,Eve,Ewa,Eve,Eve,Eve,Eve,Eva,Eve,Eve,Eve,Eve,1
+43,Mom's Knife,Mom's Knife,Item,엄마의 식칼,Ножът на мама,Mámin Nůž,Mamas Messer,Το Μαχαίρι της Μαμάς,Mom's Knife,Couteau de Maman,Coltello di Mamma,ママの包丁,Mama's Mes,Nóż Mamy,Mom's Knife,Mom's Knife,Cuțitul Mamei,Мамин нож,Cuchillo de Mamá,Annenin Bıçağı,Матусин ніж,Mom's Knife,妈妈的菜刀,1
+44,The Razor,Razor Blade,Item,면도날,Бръснарско ножче,Žiletka,Rasierklinge,Ξυριστική Λεπίδα,Razor Blade,Lame de Rasoir,Lametta,レイザー ブレード,Scheermesje,Żyletka,Razor Blade,Razor Blade,Lamă de Ras,Лезвие бритвы,Cuchilla,Jilet,Лезо бритви,Razor Blade,剃刀片,1
+45,Guardian Angel,Guardian Angel,Item,수호천사,Ангел пазител,Anděl Strážný,Schutzengel,Φύλακας Άγγελος,Guardian Angel,Ange Gardien,Angelo Custode,ガーディアン エンジェル,Beschermengel,Anioł Stróż,Guardian Angel,Guardian Angel,Îngerul Protector,Ангел-хранитель,Ángel Guardián,Koruyucu Melek,Ангел-Охоронець,Guardian Angel,守护天使,1
+46,A Bag of Bombs,Bomb Bag,Item,폭탄 주머니,Торба с бомби,Požehnaná Mince,Gesegnete Münze,Σακούλα Βόμβων,Bomb Bag,Sac de Bombes,Sacco di Bombe,幸運のペニー,Bommen Tas,Torba na Bomby,Bomb Bag,Bomb Bag,Plasă cu Bombe,Благословенный пенни,Bolsa de Bombas,Kutsanmış Para,Сумка з бомбами,Blessed Penny,炸弹袋,1
+47,Demon Baby,Demon Baby,Item,악마 아기,Бебе демон,Démoní Děcko,Dämonenbaby,Διαβολικό Μωρό,Demon Baby,Bébé Démoniaque,Bebè Demone,デーモンベイビー,Demon Baby,Demoniczne Dziecko,Demon Baby,Demon Baby,Bebelușul Demon,Малыш демон,Bebé Demonio,Şeytan Bebek,Малюк Диявол,Demon Baby,恶魔宝宝,1
+48,Forget Me Now,Forget Me Now,Item,날 잊어 주세요,Забрави за мен,Zapomeň na Mě,Vergissmeinjetzt,Ξέχνα Με Τώρα,Forget Me Now,Pilule Tranquillisante,NonTiRicordarDiMe,フォーゲットミーなぅ,Vergeet Me Nu,Zapominajka,Forget Me Now,Forget Me Now,Uită-mă Acum,Забудь меня,Olvídame Ya,Beni Unut,Забудь мене зараз,Forget Me Now,遗忘药,1
+49,The D20,D20,Item,20면 주사위,D20,Modelářská Hlína,Modelliermasse,Εικοσάπλευρο Ζάρι,D20,D20,D20,モデリング クレイ,D20,D20,D20,D20,D20,Пластилин для лепки,D20,Heykel Kili,D20,Modeling Clay,二十面骰,1
+50,Celtic Cross,Celtic Cross,Item,켈트 십자가,Келтски кръст,Azazelův Pahýl,Azazels Stumpf,Κέλτικος Σταυρός,Celtic Cross,Croix Celte,Croce Celtica,アザゼルのカケラ,Keltisch Kruis,Krzyż Celtycki,Celtic Cross,Celtic Cross,Crucea Celtică,Обрубок Азазеля,Cruz celta,Azazel'in vuruşu,Кельтський хрест,Azazel's Stump,凯尔特十字,1
+51,Abel,Abel,Item,아벨,Авел,Ábel,Abel,Αβέλ,Abel,Abel,Abele,アベル,Abel,Abel,Abel,Abel,Abel,Авель,Abel,Abel,Авель,Ice Cube,亚伯,1
+52,Curved Horn,Curved Horn,Trinket,휘어진 뿔,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,Curved Horn,1
+53,Sacrificial Dagger,Sacrificial Dagger,Item,희생의 단도,Жертвена кама,Prokletá Mince,Opferdolch,Στιλέτο Θυσίας,Sacrificial Dagger,Pièce Maudite,Penny Maledetto,イケニエの短刀,Opofferings Dolk,Sztylet Ofiarny,Sacrificial Dagger,Sacrificial Dagger,Pumnalul de Sacrificii,Жертвенный кинжал,Moneda maldita,Lanetli Para,Ніж для жертвопринесень,Sacrificial Dagger,献祭匕首,1
+54,Bloody Lust,Bloody Lust,Item,피의 욕망,Жажда за кръв,Roztrhaná Karta,Zerrissene Karte,Αιματηρή Λαγνεία,Bloody Lust,Soif de Sang,Furia Sanguinolenta,破れたカード,Bloederige Lust,Krwawa Żądza,Bloody Lust,Bloody Lust,Poftă Sângeroasă,Порванная карта,Lujuria de Sangre,Yırtık Kart,Кривава жага,Torn Card,嗜血,1
+55,Blood Penny,Bloody Penny,Trinket,피 묻은 동전,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,Bloody Penny,1
+56,Blood Rights,Blood Rights,Item,피의 권리,Кръвни права,Pokrevní Práva,Blutrechte,Δικαιώματα Αίματος,Blood Rights,Droits du Sang,Eredità di Sangue,血印,Bloed Rechten,Prawo Krwi,Blood Rights,Blood Rights,Drepturi de Sânge,Лучший друг Аполлиона,Derechos de sangre,Apollyon'un En İyi Arkadaşı,Криваві права,Blood Rights,血之权利,1
+57,The Polaroid,The Polaroid,Item,즉석사진,Полароид,Polaroid,The Polaroid,Το Πόλαροιντ,The Polaroid,Le Positif,La Polaroid,ポラロイド,The Polaroid,Polaroid,The Polaroid,The Polaroid,The Polaroid,Фотокарточка,La Polaroid,Polaroid,Полароїд,The Polaroid,全家福,1
+58,Dad's Key,Dad's Key,Item,아빠의 열쇠,Ключа на тати,Podivný Klíč,Seltsamer Schlüssel,Το Κλειδί του Μπαμπά,Dad's Key,Clé de Papa,Chiave di Papà,ストレンジ キー,Papa's Sleutel,Klucz Taty,Dad's Key,Dad's Key,Cheile Tatălui,Странный ключ,Llave de Papá,Tuhaf Anahtar,Татусів ключ,Strange Key,爸爸的钥匙,1
+59,Blue Candle,The Candle,Item,양초,Свещта,Prstencový Uzávěr,Ringkappe,Το Κερί,The Candle,Bougie Bleue,La Candela,リング キャップ,De kaars,Świeca,The Candle,The Candle,Lumânarea,Кольцевая крышка,La Vela,Halka Şapka,Свічка,Ring Cap,蓝蜡烛,1
+60,Burnt Penny,Burnt Penny,Trinket,타버린 동전,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,Burnt Penny,1
+61,Lucky Toe,Lucky Toe,Trinket,행운의 발가락,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,Lucky Toe,1
+62,Epic Fetus,Epic Fetus,Item,쩌는 태아,Епичен Ембрион,Duté Srdce,Hohles Herz,Επικό Έμβρυο,Epic Fetus,Super Fœtus,Epic Fetus,ホロウ ハート,Epic Foetus,Epicki Fetus,Epic Fetus,Epic Fetus,Fătul Epic,Полое сердце,Fetus Épico,Boş Kalp,Епічний Зародок,Hollow Heart,史诗胎儿博士,1
+63,SMB Super Fan,SMB Super Fan,Item,슈미보 광팬,Фен на Super Meat Boy,SMB Super Fanda,SMB Super Fan,SMB Σούπερ Θαυμαστής,SMB Super Fan,Super Fan de SMB,Super Fan di SMB,SMB熱狂的ファン,SMB Super Fan,Super Fan SMB,SMB Super Fan,SMB Super Fan,SMB Super Fan,Супер фанат SMB,Súper Fan de SMB,Baphometin İmzası,Суперфанат SMB,SMB Super Fan,超级食肉男孩死忠粉,1
+64,Counterfeit Coin,Counterfeit Penny,Trinket,가짜 동전,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,Counterfeit Penny,1
+65,Guppy's Hairball,Guppy's Hairball,Item,구피의 털뭉치,Топката косми на Гъпи,Rozbité Brýle,Kaputte Brille,Η Μπούκλα του Γκάπι,Guppy's Hairball,Boule de Poils de Guppy,Palla di Pelo di Guppy,壊れたメガネ,Guppy's Haarbal,Kłaczek Guppy'ego,Guppy's Hairball,Guppy's Hairball,Mingea de Păr a lui Guppy,Разбитые очки,Bola de pelo de Guppy,Kırık Gözlük,Клубок шерсті Гаппі,Broken Glasses,嗝屁猫的毛球,1
+66,A Forgotten Horseman,Conquest,Boss,,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,Conquest,1
+67,Samson,Samson,Character,삼손,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Samson,Sansón,Samson,Samson,Samson,Samson,1
+68,Something Icky,Triachnid,Boss,,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,Triachnid,1
+69,!Platinum God!,!Platinum God!,None,,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,!Platinum God!,1
+70,Isaac's Head,Isaac's Head,Trinket,아이작의 머리,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,Isaac's Head,1
+71,Maggy's Faith,Maggy's Faith,Trinket,매기의 믿음,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,Maggy's Faith,1
+72,Judas' Tongue,Judas' Tongue,Trinket,유다의 혀,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,Judas' Tongue,1
+73,???'s Soul,???'s Soul,Trinket,???의 영혼,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,???'s Soul,1
+74,Samson's Lock,Samson's Lock,Trinket,삼손의 머리채,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,Samson's Lock,1
+75,Cain's Eye,Cain's Eye,Trinket,카인의 오른쪽 눈,000,Kniha Belialova,Das Buch von Belial,Το Μάτι του Κάιν,Cain's Eye,Œil de Caïn,Occhio di Caino,ベリアルの本,Cain's Eye,Oko Kaina,Cain's Eye,Cain's Eye,Cain's Eye,Книга Белиала,Ojo de Caín,III - İmparatoriçe?,Око Каїна,The Book of Belial,该隐的眼睛,1
+76,Eve's Bird Foot,Eve's Bird Foot,Trinket,이브의 새 다리,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,Eve's Bird Foot,1
+77,The Left Hand,The Left Hand,Trinket,왼손목,000,V - Velekněz?,V - Der Hierophant?,Το Αριστερό Χέρι,The Left Hand,Main Gauche,La Mano Sinistra,V - 教皇？,The Left Hand,Lewa Ręka,The Left Hand,The Left Hand,The Left Hand,V - Иерофант?,La Mano izquierda,V - Papa?,Ліва рука,V - The Hierophant?,左断手,1
+78,The Negative,The Negative,Item,반전사진,Негатив,Negativ,Das Negative,Το Αρνητικό,The Negative,Le Négatif,Il Negativo,ネガティブ,The Negative,Negatyw,The Negative,The Negative,The Negative,Негатив,El Negativo,Negatif,Негатив,The Negative,底片,1
+79,Azazel,Azazel,Character,아자젤,Azazel,Azazel,Azazel,Azazel,Azazel,Peut voler#Crache un court laser de sang,"Volo##{{Collectible118}} Al posto delle lacrime ""Zolfo Fuso"" dal corto raggio",Azazel,Azazel,Azazel,Azazel,Azazel,Flight#{{Collectible118}} Short range Brimstone instead of tears,Azazel,Puede volar#{{Collectible118}} Dispara un rayo de corto alcance en vez de lágrimas,Azazel,Azazel,Azazel,Azazel,1
+80,Lazarus,Lazarus,Character,나사로,Lazarus,"Jednou za patro, když zemřeš:#Vzkříšíš se jako Povstalý Lazarus#Ztratíš 1 místo pro červené srdce#↑ {{Damage}} 0.5 Více poškození",Lazarus,Lazarus,Lazarus,Lazare,Lazarus,1フロアに1回、死亡時に 以下の効果を発動する：#復活ラザラスとして その部屋で復活#↓ 最大体力 -1#↑ 攻撃力 +1,Lazarus,Łazarz,Lazarus,Lazarus,"When you die, resurrect as Lazarus Risen with 1 Red Heart container",Lazarus,Lázaro,Lazarus,Lazarus,"Một lần mỗi tầng, khi bạn chết:#Hồi sinh thành Lazarus Risen#Mất 1 ô chứa Trái tim đỏ#↑ {{Damage}} +0.5 Sát thương",Lazarus,1
+81,Eden,Eden,Character,에덴,Eden,Eden,Eden,Eden,Eden,Éden,Ogni partita inizia con statistiche e oggetti casuali,Eden,Eden,Eden,Eden,Eden,Start with random stats and items each run,Eden,Edén,Eden,Eden,Eden,Eden,1
+82,The Lost,The Lost,Character,로스트,The Lost,Létání#Spektrální slzy#{{Warning}} Žádné životy#{{DevilRoom}} Jeden ďábelský předmět za místnost je zdarma,The Lost,The Lost,The Lost,L'Égaré,The Lost,The Lost,The Lost,Zaginiony,The Lost,The Lost,Flight#Spectral tears#{{Warning}} No health#{{DevilRoom}} One devil deal per room can be taken for free,The Lost,El Perdido,The Lost,The Lost,The Lost,The Lost,1
+83,Dead Boy,Dead Boy,None,,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,Dead Boy,1
+84,The Real Platinum God,The Real Platinum God,None,,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,The Real Platinum God,1
+85,Lucky Rock,Lucky Rock,Trinket,행운의 돌조각,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,Lucky Rock,1
+86,The Cellar,Alt stage to the basement.,Map,,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,Alt stage to the basement.,1
+87,The Catacombs,Alt stage to the caves.,Map,,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,Alt stage to the caves.,1
+88,The Necropolis,Alt stage to the depths.,Map,,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,Alt stage to the depths.,1
+89,Hagalaz,Hagalaz,Rune,하갈라즈,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,Hagalaz,1
+90,Jera,Jera,Rune,제라,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,Jera,1
+91,Ehwaz,Ehwaz,Rune,에와즈,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,Ehwaz,1
+92,Dagaz,Dagaz,Rune,다가즈,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,Dagaz,1
+93,Ansuz,Ansuz,Rune,엔수즈,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,Ansuz,1
+94,Perthro,Perthro,Rune,페트로,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,Perthro,1
+95,Berkano,Berkano,Rune,벨카노,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,Berkano,1
+96,Algiz,Algiz,Rune,알기즈,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,Algiz,1
+97,Chaos Card,Chaos Card,Card,혼돈 카드,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,Chaos Card,1
+98,Credit Card,Credit Card,Card,신용카드,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,Credit Card,1
+99,Rules Card,Rules Card,Card,규칙 카드,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,Rules Card,1
+100,Card Against Humanity,A Card Against Humanity,Card,비인간적인 카드,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,A Card Against Humanity,1
+101,Swallowed Penny,Swallowed Penny,Trinket,삼킨 동전,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,Swallowed Penny,1
+102,Robo-Baby 2.0,Robo-Baby 2.0,Item,로보 아기 2.0,Робо-бебе 2.0,Robo-Děcko 2.0,Robo-Baby 2.0,Ρομποτικό-Μωρό 2.0,Robo-Baby 2.0,Robo-Bébé 2.0,Robo-Bebè 2.0,ロボベイビー改,Robo-Baby 2.0,Robo-Dziecko 2.0,Robo-Baby 2.0,Robo-Baby 2.0,Robo-Bebeluș 2.0,Робо-малыш 2.0 ,Robo-Baby 2.0,Robo-Bebek 2.0,Робо-дитя 2.0,Robo-Baby 2.0,机器宝宝2.0,1
+103,Death's Touch,Death's Touch,Item,죽음의 손길,Докосването на смъртта,Dotek Smrti,Death's Touch,Το Άγγιγμα του Θανάτου,Death's Touch,La Faucheuse,Tocco Mortale,死神タッチ,Death's Touch,Dotyk Śmierci,Death's Touch,Death's Touch,Atingerea Morții,Прикосновение Смерти,Toque de la Muerte,Ölümün Dokunuşu,Дотик смерті,Death's Touch,死神之触,1
+104,Technology .5,Tech.5,Item,기계 0.5,Техно.5,Tech.5,Tech.5,Τεχνολογία.5,Tech.5,"Tech 0,5",Tecn. 0.5,テック０.５,Tech.5,Tech.5,Tech.5,Tech.5,Tehn.5,Технология.5,Tech.5,Tekn.5,Технологія 0.5,Tech.5,科技0.5,1
+105,Missing No.,Missing No.,Item,Missing No.,Изгубен №,Chybějící č.,Missing No.,Missingno.,Missing No.,Missing No.,Missing No.,けつばん,Missing No.,Missing No.,Missing No.,Missing No.,Nr. Lipsă,Потерянный №,Missing No.,Kayıp No.,Загублений біт,Missing No.,编号丢失,1
+106,Isaac's Tears,Isaac's Tears,Item,아이작의 눈물,Сълзите на Исаак,Izákovy Slzy,Isaacs Tränen,Τα Δάκρυα του Ισαάκ,Isaac's Tears,Bocal de Larmes,Lacrime di Isaac,アイザックのナミダ,Isaac's Tears,Łzy Izaaka,Isaac's Tears,Isaac's Tears,Isaac's Tears,Слезы Исаака,Lágrimas de Isaac,Isaac's Tears,Сльози Ісаака,Isaac's Tears,以撒的泪盆,1
+107,Guillotine,Guillotine,Item,단두대,Гилотина,Gilotina,Guillotine,Καρμανιόλα,Guillotine,Guillotine,Ghigliottina,ギロチン,Guillotine,Gilotyna,Guillotine,Guillotine,Ghilotină,Гильотина,Guillotina,Giyotin,Гільйотина,Guillotine,断头台,1
+108,Judas' Shadow,Judas' Shadow,Item,유다의 그림자,Сянката на Юда,Jidášův Stín,Judas' Shadow,Η Σκιά του Ιούδα,Judas' Shadow,Ombre de Judas,Ombra di Giuda,ユダの影,Judas' Shadow,Cień Judasza,Judas' Shadow,Judas' Shadow,Judas' Shadow,Тень Иуды,Sombra de Judas,Judas'ın Gölgesi,Тінь Юди,Judas' Shadow,犹大的影子,1
+109,Maggy's Bow,Maggy's Bow,Item,매기의 리본,Панделката на Маги,Maggyina Mašle,Maggy's Bow,Φιόγκος της Μάγκι,Maggy's Bow,Chouchou de Marie,Fiocco di Madda,マギーのリボン,Maggy's Bow,Kokardka Madzi,Maggy's Bow,Maggy's Bow,Maggy's Bow,Бант Мэгги,Moño de Maggy,Maggy'nin Yayı,Бантик Меггі,Maggy's Bow,抹大拉的蝴蝶结,1
+110,Cain's Other Eye,Cain's Other Eye,Item,카인의 왼쪽 눈,Другото око на Каин,Kainovo Druhé Oko,Cains Anderes Auge,Το Άλλο Μάτι του Κάιν,Cain's Other Eye,Œil Gauche de Caïn,L'Altro Occhio di Caino,ケインの予備眼,Cain's Other Eye,Drugie Oko Kaina,Cain's Other Eye,Cain's Other Eye,Cain's Other Eye,Другой глаз Каина,El otro ojo de Caín,Cain'in Diğer Gözü,Інше око Каїна,Cain's Other Eye,该隐的另一只眼,1
+111,Black Lipstick,Black Lipstick,Trinket,검은 립스틱,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,Black Lipstick,1
+112,Eve's Mascara,Eve's Mascara,Item,이브의 마스카라,Спиралата на Ева,Evina Řasenka,Evas Mascara,Η Μάσκαρα της Εύας,Eve's Mascara,Mascara d'Ève,Mascara di Eva,イブのマスカラ,Eve's Mascara,Maskara Ewy,Eve's Mascara,Eve's Mascara,Eve's Mascara,Тушь Евы,Rímel de Eva,Annenin Rimeli,Туш Єви,Eve's Mascara,夏娃的睫毛膏,1
+113,Fate,Fate,Item,운명,Съдба,RC Dálkové Ovládání,RC-Fernbedienung,Μοίρα,Fate,Destin,Destino,ＲＣリモート,Lot,Przeznaczenie,Fate,Fate,Soartă,Пульт радиоуправления,Destino,RC Kumanda,Доля,RC Remote,宿命,1
+114,???'s Only Friend,???'s Only Friend,Item,???의 하나뿐인 친구,Единственият приятел на ???,Jediný Přítel ???,???s Einziger Freund,Ο Μόνος Φίλος του ???,???'s Only Friend,La Seule Amie de ???,L'Unico Amico di ???,？？？唯一の友,???'s Only Friend,Jedyny Przyjaciel ???,???'s Only Friend,???'s Only Friend,???'s Only Friend,Единственный друг ???,Único amigo de ???,???'nin Tek Arkadaşı,Єдиний друг ???,???'s Only Friend,???唯一的朋友,1
+115,Samson's Chains,Samson's Chains,Item,삼손의 쇠사슬,Веригите на Самсон,Samsonovy Řetězy,Samson's Chains,Οι Αλυσίδες του Σαμψών,Samson's Chains,Boulet de Samson,Catene di Sansone,サムソンの鎖,Samson's Chains,Łańcuch Samsona,Samson's Chains,Samson's Chains,Samson's Chains,Цепи Самсона,Cadenas de Sansón,Samson's Chains,Кайдани Самсона,Samson's Chains,参孙的脚镣,1
+116,Lazarus' Rags,Lazarus' Rags,Item,나사로의 붕대,Дрипите на Лазар,Lazarovy Hadry,Lazarus' Rags,Τα Κουρέλια του Λαζάρου,Lazarus' Rags,Loques de Lazare,Bende di Lazzaro,ラザラスのぼろきれ,Lazarus' Rags,Łachmany Łazarza,Lazarus' Rags,Lazarus' Rags,Lazarus' Rags,Лохмотья Лазаря,Harapos de Lázaro,Lazarus'un Bezleri,Ганчір'я Лазаря,Lazarus' Rags,拉撒路的绷带,1
+117,Broken Ankh,Broken Ankh,Trinket,부서진 앙크,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,Broken Ankh,1
+118,Store Credit,Store Credit,Trinket,상점 상품권,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,Store Credit,1
+119,Pandora's Box,Pandora's Box,Item,판도라의 상자,Кутията на Пандора,Pandořina Skříňka,Pandoras Box,Το Κουτί της Πανδώρας,Pandora's Box,Boîte de Pandore,Scrigno di Pandora,パンドラの箱,Pandora's Box,Puszka Pandory,Pandora's Box,Pandora's Box,Pandora's Box,Ящик Пандоры,Caja de Pandora,Pandora'nın Kutusu,Скринька Пандори,Pandora's Box,潘多拉魔盒,1
+120,Suicide King,Suicide King,Card,자살 왕,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,Suicide King,1
+121,Blank Card,Blank Card,Item,빈 카드,Празна карта,Prázdná Karta,Blanko-Karte,Κενή Κάρτα,Blank Card,Carte Blanche,Carta Bianca,白紙のカード,Blank Card,Czysta Karta,Blank Card,Blank Card,Carte Albă,Пустая карта,Carta en Blanco,Boş Kart,Порожня карта,Blank Card,空白卡牌,1
+122,Book of Secrets,Book of Secrets,Item,비밀의 책,Книга на тайните,Kniha Tajemství,Buch der Geheimnisse,Βιβλίο των Μυστικών,Book of Secrets,Livre des Secrets,Libro dei Segreti,秘儀の書,Book of Secrets,Księga Tajemnic,Book of Secrets,Book of Secrets,Cartea Secretelor,Книга тайн,Libro de Secretos,Sırlar Kitabı,Книга Таїнств,Book of Secrets,秘密之书,1
+123,Mysterious Paper,Mysterious Paper,Trinket,신비한 종이,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,Mysterious Paper,1
+124,Mystery Sack,Mystery Sack,Item,수수께끼의 주머니,Тайнствена торбичка,Tajemný Pytel,Mystery Sack,Μυστηριώδης Σάκος,Mystery Sack,Pochon Mystère,Sacco delle Meraviglie,謎の袋,Mystery Sack,Sakiewka Tajemnic,Mystery Sack,Mystery Sack,Sac Misterios,Загадочный мешочек,Bolsa misteriosa,Gizemli Kese,Загадковий мішечок,Mystery Sack,神秘的袋子,1
+125,Undefined,Undefined,Item,Undefined,Неопределено,Nedefinováno,Undefined,Απροσδιόριστο,Undefined,erreur,Indefinito,未定義,Undefined,Niezdefiniowane,Undefined,Undefined,Undefined,Неопределённый,Undefined,Undefined,Невизначено,Undefined,未定义,1
+126,Satanic Bible,Satanic Bible,Item,사탄경,Сатанистка Библия,Satanská Bible,Satanische Bibel,Σατανική Βίβλος,Satanic Bible,Bible Satanique,Bibbia Satanica,邪悪な聖書,Satanic Bible,Biblia Szatana,Satanic Bible,Satanic Bible,Biblie Satanică,Сатанинская Библия,Biblia Satánica,Şeytanın İncili,Сатанинська біблія,Satanic Bible,撒但圣经,1
+127,Daemon's Tail,Daemon's Tail,Trinket,악마 꼬리,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,Daemon's Tail,1
+128,Abaddon,Abaddon,Item,아바돈,Абадон,Abaddón,Abaddon,Αμπέδον,Abaddon,Abaddon,Abaddon,アバドン,Abaddon,Abaddon,Abaddon,Abaddon,Abaddon,Абаддон,Abaddón,Abaddon,Абаддон,Abaddon,亚巴顿,1
+129,Isaac's Heart,Isaac's Heart,Item,아이작의 심장,Сърцето на Исаак,Izákovo Srdce,Isaacs Herz,Η Καρδιά του Ισαάκ,Isaac's Heart,Cœur d'Isaac,Cuore di Isaac,アイザックの心臓,Isaac's Heart,Serce Izaaka,Isaac's Heart,Isaac's Heart,Inima lui Isaac,Сердце Исаака,Corazón de Isaac,Isaac'in Kalbi,Серце Ісаака,Isaac's Heart,以撒的心脏,1
+130,The Mind,The Mind,Item,정신,Разум,Mysl,The Mind,Το Μυαλό,The Mind,L'Esprit,La Mente,ザ マインド,The Mind,Umysł,The Mind,The Mind,The Mind,Разум,La Mente,Akıl,Розум,The Mind,思想,1
+131,The Body,The Body,Item,육체,Тяло,Tělo,The Body,Το Σώμα,The Body,Le Corps,Il Corpo,ザ ボディー,The Body,Ciało,The Body,The Body,The Body,Тело,El Cuerpo,Vücut,Тіло,The Body,肉体,1
+132,The Soul,The Soul,Item,영혼,Душа,Duše,The Soul,Η Ψυχή,The Soul,L'Âme,L'Anima,ザ ソウル,The Soul,Dusza,The Soul,The Soul,The Soul,Душа,El Alma,Ruh,Душа,The Soul,灵魂,1
+133,The D100,D100,Item,100면 주사위,D100,D100,D100,Εκατόπλευρο Ζάρι,D100,D100,D100,D100,D100,D100,D100,D100,D100,D100,D100,D100,D100,D100,一百面骰,1
+134,Blue Map,Blue Map,Item,파란 지도,Синя карта,Modrá Mapa,Blue Map,Μπλε Χάρτης,Blue Map,Carte Perdue,Mappa Blu,ブルーマップ,Blue Map,Niebieska Mapa,Blue Map,Blue Map,Hartă Albastră,Голубая карта,Mapa azul,Mavi Harita,Синя карта,Blue Map,蓝地图,1
+135,There's Options,There's Options,Item,추가 선택권,Има опции,Jsou Tu Možnosti,There's Options,Υπάρχουν Επιλογές,There's Options,L'Embarras du Choix,Ci sono alternative,オプションあり,There's Options,Istnieją Możliwości,There's Options,There's Options,Sunt Opțiuni,Выбор есть,Hay opciones,Seçenekler Var,У тебе є вибір,There's Options,额外选择,1
+136,Black Candle,Black Candle,Item,검은 양초,Черна свещ,Černá Svíčka,Black Candle,Μαύρο Κερί,Black Candle,Bougie Noire,Candela Nera,ブラックキャンドル,Black Candle,Czarna Świeca,Black Candle,Black Candle,Lumânarea Neagră,Чёрная свеча,Vela negra,Siyah Mum,Чорна свічка,Black Candle,黑蜡烛,1
+137,Red Candle,Red Candle,Item,빨간 양초,Червена свещ,Červená Svíčka,Rote Kerze,Κόκκινο Κερί,Red Candle,Bougie Rouge,Candela Rossa,赤いロウソク,Red Candle,Czerwona Świeca,Red Candle,Red Candle,Lumânare Roșie,Красная свеча,Vela roja,Kırmızı Mum,Червона свічка,Red Candle,红蜡烛,1
+138,Stop Watch,Stop Watch,Item,스톱워치,Секундомер,Stopky,Stoppuhr,Χρονόμετρο,Stop Watch,Chronomoètre,Cipollotto,ストップウォッチ,Stop Watch,Stop-Er,Stop Watch,Stop Watch,Cronometru,Секундомер,Cronómetro,Kronometre,Секундомір,Stop Watch,怀表,1
+139,Wire Coat Hanger,Wire Coat Hanger,Item,철제 옷걸이,Закачалка,Hagalaz,Freiheitskappe,Καλωδιακής κρεμάστρα,Wire Coat Hanger,Hagalaz,Hagalaz,リバティーキャップ,Draadhanger,Druciany Wieszak,Wire Coat Hanger,Wire Coat Hanger,Cuier de Sârmă,Вольная шляпка,Hagalaz,Özgürlük Şapkası,Вішак для одягу,Liberty Cap,铁丝衣架,1
+140,Ipecac,Ipecac,Item,구토제,Буркан с отрова,Ipekak,Ipecac,Ιπεκακουάνας,Ipecac,Ipéca,Ipecac,吐き気薬,Ipecac,Wymiotnica,Ipecac,Ipecac,Ipecac,Рвотный корень,Ipecac,Ipecac,Іпекак,Ipecac,吐根酊,1
+141,Experimental Treatment,Experimental Treatment,Item,임상시험,Експериментално лечение,Experimentální Léčba,Experimental Treatment,Πειραματική Θεραπεία,Experimental Treatment,Traitement Expérimental,Trattamento Sperimentale,実験的治療方法,Experimental Treatment,Terapia Eksperymentalna,Experimental Treatment,Experimental Treatment,Tratament Experimental,Экспериментальное лечение,Tratamiento experimental,Deneysel Tedavi,Експериментальне лікування,Experimental Treatment,实验性疗法,1
+142,Krampus,Krampus,Boss,크람푸스,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,Krampus,1
+143,Head of Krampus,Head of Krampus,Item,크람푸스의 머리,Главата на Крампус,Krampusova Hlava,Head of Krampus,Κεφάλι του Κράμπος,Head of Krampus,Tête de Krampus,Testa di Krampus,クランプスの頭,Head of Krampus,Głowa Krampusa,Head of Krampus,Head of Krampus,Capul lui Krampus,Голова Крампуса,Cabeza de Krampus,Krampusun Kafası,Голова Крампуса,Head of Krampus,坎卜斯的头,1
+144,Super Meat Boy,Cube of Meat,Item,고기조각,Куб от месо,XVII - Hvězda?,XVII - Die Sterne?,Κύβος κρέατος,Cube of Meat,Cube de Viande,Cubo di Carne,XVII - 星？,Kubus van vlees,Kostka Mięsa,Cube of Meat,Cube of Meat,Un Cub de Carne,XVII - Звёзды?,Cubo de carne,XVII - Yıldızlar?,Кубик м'яса,XVII - The Stars?,肉块,1
+145,Butter Bean,Butter Bean,Item,흰강낭콩,Маслен боб,Máslová Fazole,Butterbohne,Φασόλι Βουτύρου,Butter Bean,Haricot Blanc,Fagiolo di Lima,バタービーンズ,Butter Bean,Maślana Fasola,Butter Bean,Butter Bean,Fasole Lima,Масленый боб,Frijol Mantequilla,Margarin Kuru Fasülyesi,Масляний біб,Butter Bean,棉豆,1
+146,Little Baggy,Little Baggy,Item,작은 주머니,Малка торбичка,Malý Pytlík,Little Baggy,Μικρή Τσαντούλα,Little Baggy,Petit Sachet,Portapillole,こぶくろ,Little Baggy,Torebeczka,Little Baggy,Little Baggy,Mica Punguță,Маленький мешочек,Pequeña bolsa,Minik Çanta,Маленький мішечок,Little Baggy,小药袋,1
+147,Blood Bag,Blood Bag,Item,혈액 팩,Пакет с кръв,Kmenová Buňka,Stammzelle,Σάκος Αίματος,Blood Bag,Poche de Sang,Sacca di sangue,幹細胞,Bloedzak,Worek na Krew,Blood Bag,Blood Bag,Pungă cu Sânge,Стволовая клетка,Bolsa de Sangre,Kök Hücre,Мішок крові,Stem Cell,血袋,1
+148,The D4,D4,Item,4면 주사위,D4,D4,D4,Τετράπλευρο Ζάρι,D4,D4,D4,D4,D4,D4,D4,D4,D4,D4,D4,D4,D4,D4,四面骰,1
+149,Missing Poster,Missing Poster,Trinket,실종 포스터,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,Missing Poster,1
+150,Rubber Cement,Rubber Cement,Item,고무 접착제,Гумено лепило,Gumový Cement,Gummizement,Τσιμέντο Καουτσούκ,Rubber Cement,Colle Caoutchouc,Mastice,ゴムセメント,Rubber Cement,Klej Kauczukowy,Rubber Cement,Rubber Cement,Ciment de Cauciuc,Резиновый клей,Pegamento Elástico,Lastik Çimento,Гумовий клей,Rubber Cement,橡胶胶水,1
+151,Store Upgrade lv.1,Store Upgrade lv.1,Other,상점 업그레이드 Lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,Store Upgrade lv.1,1
+152,Store Upgrade lv.2,Store Upgrade lv.2,Other,상점 업그레이드 Lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,Store Upgrade lv.2,1
+153,Store Upgrade lv.3,Store Upgrade lv.3,Other,상점 업그레이드 Lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,Store Upgrade lv.3,1
+154,Store Upgrade lv.4,Store Upgrade lv.4,Other,상점 업그레이드 Lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,Store Upgrade lv.4,1
+155,Angels,Angel,Boss,천사 석상 파괴가능,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,Angel,1
+156,Godhead,Godhead,Item,신,Божественост,Božství,Götterkopf,Θεότης,Godhead,Œil de la Providence,Divinità,神の首,Godhead,Bóstwo,Godhead,Godhead,Godhead,Божественность,Deidad,TanrıKafası,Божество,Godhead,神性,1
+157,Darkness Falls,Darkness Falls,None,챌린지4,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,Darkness Falls,1
+158,The Tank,The Tank,None,챌린지5,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,The Tank,1
+159,Solar System,Solar System,None,챌린지6,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,Solar System,1
+160,Suicide King,Suicide King (Challenge),None,챌린지7,Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),Suicide King (Challenge),1
+161,Cat Got Your Tongue,Cat Got Your Tongue,None,챌린지8,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,Cat Got Your Tongue,1
+162,Demo Man,Demo Man,None,챌린지9,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,Demo Man,1
+163,Cursed!,Cursed!,None,챌린지10,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,Cursed!,1
+164,Glass Cannon,Glass Cannon (Challenge),None,챌린지11,Стъклено оръдие,Skleněné Dělo,Glas-Kanone,Κανόνι από Γυαλί,Glass Cannon (Challenge),Canon de Verre,Cannone di Vetro,ガラスの大砲,Glass Cannon,Szklana Armata,Glass Cannon (Challenge),Glass Cannon (Challenge),Glass Cannon,Стеклянная пушка,Cañón de cristal,Cam Topu,Скляна гармата,Glass Cannon,玻璃大炮,1
+165,The Family Man,The Family Man,None,챌린지19,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,The Family Man,1
+166,Purist,Purist,None,챌린지20,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,Purist,1
+167,Lost Baby,Lost Baby,Other,랜덤 패밀리어,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,Lost Baby,1
+168,Cute Baby,Cute Baby,Other,랜덤 패밀리어,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,Cute Baby,1
+169,Crow Baby,Crow Baby,Other,랜덤 패밀리어,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,Crow Baby,1
+170,Shadow Baby,Shadow Baby,Other,랜덤 패밀리어,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,Shadow Baby,1
+171,Glass Baby,Glass Baby,Other,랜덤 패밀리어,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,Glass Baby,1
+172,Wrapped Baby,Wrapped Baby,Other,랜덤 패밀리어,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,Wrapped Baby,1
+173,Begotten Baby,Begotten Baby,Other,랜덤 패밀리어,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,Begotten Baby,1
+174,Dead Baby,Dead Baby,Other,랜덤 패밀리어,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,Dead Baby,1
+175,#NAME?,#NAME?,Other,랜덤 패밀리어,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,#NAME?,1
+176,Glitch Baby,Glitch Baby,Other,랜덤 패밀리어,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,Glitch Baby,1
+177,Fighting Baby,Fighting Baby,Other,랜덤 패밀리어,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,Fighting Baby,1
+178,Lord of the Flies,Beelzebub,Other,Beelzebub 세트 해금,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,Beelzebub,1
+179,Fart Baby,Farting Baby,Item,방귀쟁이 아기,Детето Пръдня,Prdící Děcko,Furz-Baby,Μωρό που Κλάνει,Farting Baby,Bébé Péteur,Bebè Scoreggione,ファーティング ベイビー,Farting Baby,Pierdzący Dzieciak,Farting Baby,Farting Baby,Farting Baby,Пукающий малыш,Bebé Tira-Pedos,Osuran Bebek,Малюк Пердун,Farting Baby,放屁宝宝,1
+180,Purity,Purity,Item,순도,Чистота,Čistota,Reinheit,Αγνότητα,Purity,Pureté,Purezza,純潔,Purity,Czystość,Purity,Purity,Purity,Чистота,Pureza,Sadelik,Чистота,Purity,纯洁,1
+181,D12,D12,Item,12면 주사위,D12,D12,D12,Δωδεκάπλευρο Ζάρι,D12,D12,D12,D12,D12,D12,D12,D12,D12,D12,D12,D12,D12,D12,十二面骰,1
+182,Betrayal,Betrayal,Item,배신,Предателство,Zrada,Verrat,Προδοσία,Betrayal,Trahison,Tradimento,裏切り,Betrayal,Zdrada,Betrayal,Betrayal,Betrayal,Предательство,Traición,İhanet,Зрадник,Betrayal,背叛,1
+183,Fate's Reward,Fate's Reward,Item,운명의 보상,Подарък от съдбата,Odměna Osudu,Fate's Reward,Η Ανταμοιβή της Μοίρας,Fate's Reward,Récompense du Destin,Dono del Destino,運命からのごほうび,Fate's Reward,Nagroda od Losu,Fate's Reward,Fate's Reward,Fate's Reward,Дар судьбы,Premio del destino,Kaderin Ödülü,Нагорода долі,Fate's Reward,宿命的报答,1
+184,Athame,Athame,Item,마법 단검,Атаме,Athame,Athame,Αθάμη,Athame,Athamé,Athame,儀式の刃,Athame,Athame,Athame,Athame,Athame,Атаме,Athame,Athame,Атаме,Athame,祭祀之刃,1
+185,Blind Rage,Blind Rage,Trinket,눈먼 분노,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,Blind Rage,1
+186,Maw of the Void,Maw Of The Void,Item,공허의 구렁텅이,Паст от пустотата,Chřtán Prázdnoty,Schlund der Leere,Στόμα του Κενού,Maw Of The Void,Gouffre du Néant,Fauci dell'Oblio,モー オブ ザ ボイド,Maw of the Void,Paszcza z Pustki,Maw Of The Void,Maw Of The Void,Maw of the Void,Пасть бездны,Fauces del Vacío,Maw of the Void,Паща Порожнечі,Maw of the Void,虚空之喉,1
+187,Empty Vessel,Empty Vessel,Item,빈 그릇,Празен съд,Prázdná Nádoba,Empty Vessel,Άδειο 'Σκάφος',Empty Vessel,Flacon Vide,Recipiente Vuoto,からっぽの器,Empty Vessel,Puste Naczynie,Empty Vessel,Empty Vessel,Empty Vessel,Пустой сосуд,Recipiente vacío,Boş Kase,Пуста посудина,Empty Vessel,空容器,1
+188,Eden's Blessing,Eden's Blessing,Item,에덴의 축복,Благословията на Едем,Edenovo Požehnání,Eden's Blessing,Η Ευλογία του Εδέμ,Eden's Blessing,Bénédiction d'Éden,Benedizione di Eden,エデンのご加護,Eden's Blessing,Błogosławieństwo Edena,Eden's Blessing,Eden's Blessing,Eden's Blessing,Благословение Эдема,Bendición del Edén,Eden'in Kutsaması,Едемове благословення,Eden's Blessing,伊甸的祝福,1
+189,Sworn Protector,Sworn Protector,Item,맹세한 수호자,Заклет протектор,Zapřísáhlý Ochránce,Sworn Protector,Ορκισμένος Προστάτης,Sworn Protector,Protecteur Dévoué,Eterno Protettore,誓約の守護者,Sworn Protector,Zaprzysiężony Obrońca,Sworn Protector,Sworn Protector,Sworn Protector,Присягнувший защитник,Protector fiel,Yeminli Koruyucu,Затятий захисник,Sworn Protector,宣誓守护者,1
+190,Incubus,Incubus,Item,인큐버스,Инкуб,Inkubus,Brutus,Εφιάλτης,Incubus,Incube,Incubo,インキュバス,Incubus,Inkub,Incubus,Incubus,Incubus,Инкуб,Íncubo,Incubus,Інкуб,Incubus,淫魔,1
+191,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Other,키퍼가 1코인을 가짐,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,Keeper now holds... A Penny!,1
+192,Lil' Chest,Lil Chest,Item,꼬마 상자,Малък сандък,Maličká Truhla,Lil Chest,Μικρούλι Σεντούκι,Lil Chest,P'tit Coffre,Bauletto,小さな収納箱,Lil Chest,Skrzyneczka,Lil Chest,Lil Chest,Lil Chest,Маленький сундучок,Mini-Cofre,Minik Sandık,Крихітна скринька,Lil Chest,小箱子,1
+193,Censer,Censer,Item,향로,Кадилница,Kadidelnice,Censer,Θυμιατήρι,Censer,Encensoir,Incensiere,香炉,Censer,Kadzielnica,Censer,Censer,Censer,Кадило,Incensario,Tütsülük,Кадило,Censer,香炉,1
+194,Evil Eye,Evil Eye,Item,악마의 눈,Зло око,Oko Zla,Evil Eye,Κακό Μάτι,Evil Eye,Mauvais Œil,Malocchio,邪眼,Evil Eye,Złe Oko,Evil Eye,Evil Eye,Evil Eye,Злой глаз,Mal de Ojo,Nazar,Зле око,Evil Eye,邪恶之眼,1
+195,My Shadow,My Shadow,Item,내 그림자,Моята сянка,Můj Stín,Mein Schatten,Η Σκιά Μου,My Shadow,Mon Ombre,La Mia Ombra,ぼくの影,My Shadow,Mój Cień,My Shadow,My Shadow,My Shadow,Моя тень,Mi sombra,Gölgem,Моя тінь,My Shadow,我的影子,1
+196,Cracked Dice,Cracked Dice,Trinket,금이 간 주사위,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,Cracked Dice,1
+197,Black Feather,Black Feather,Trinket,검은 깃털,Black Feather,↑ {{Damage}} +0.5 Poškození,Black Feather,Black Feather,Black Feather,↑ Dégâts {{ColorLime+0.2}},↑ {{Damage}} +0.2 Danni,↑ 攻撃力 +0.5,Black Feather,Black Feather,Black Feather,Black Feather,↑ {{Damage}} +0.2 Damage,Black Feather,↑ {{Damage}} Daño +0.2,Black Feather,Black Feather,↑ {{Damage}} +0.5 Sát thương,↑ {{Damage}} 伤害+0.2,1
+198,Lusty Blood,Lusty Blood,Item,욕망의 피,Жадуваща кръв,Chutná Krev,Lusty Blood,Λαγνεϊκό Αίμα,Lusty Blood,Sang Salace,Sangue Furente,頑健ブラッド,Lusty Blood,Żądna Krew,Lusty Blood,Lusty Blood,Lusty Blood,Вожделенная кровь,Sangre lujuriosa,Tutkulu Kan,Ненаситна кров,Lusty Blood,血嗜,1
+199,Lilith,Lilith,Character,릴리스,Lilith,Lilith,Lilith,Lilith,Lilith,Double les dégâts de l'{{ColorYellow}}Incube,"Il danno di ""Incubo"" viene raddoppiato",Lilith,Lilith,Lilit,Lilith,Lilith,Incubus damage is doubled,Lilith,Duplica el daño de Íncubo,Lilith,Lilith,Lilith,淫魔伤害翻倍,1
+200,Key Bum,Key Bum,Item,열쇠 거지,Просяк за ключове,Klíčový Žebrák,Key Bum,Αλήτης Κλειδιών,Key Bum,Cléchard,Scrocchiave,キー バム,Key Bum,Klucznik,Key Bum,Key Bum,Key Bum,Ключник-бездельник,Pordiosero de Llaves,Anahtar Evsizi,Жебрак-ключник,Key Bum,钥匙乞丐,1
+201,GB Bug,GB Bug,Item,게임 버그,Фатален бъг,Hru Rozbíjející Chyba,GB Bug,GB Μικροβλάβη,GB Bug,Bug,Bug Rompigioco,ＧＢバグ,GB Bug,GB Bug,GB Bug,GB Bug,GB Bug,Игровой баг,Error crítico,GB Hatası,Ігровий баг,GB Bug,恶性漏洞,1
+202,Zodiac,Zodiac,Item,황도궁,Зодиак,Zvěrokruh,Zodiac,Ζωδιακός,Zodiac,Zodiaque,Zodiaco,ゾディアック,Zodiac,Zodiak,Zodiac,Zodiac,Zodiac,Зодиак,Zodíaco,Burç,Зодіак,Zodiac,黄道十二宫,1
+203,Box of Friends,Box of Friends,Item,친구 상자,Кутия с приятели,Krabice s Kamarády,Box of Friends,Κουτί των Φίλων,Box of Friends,Boîte de Potes,Scatola degli Amici,おともだちボックス,Box of Friends,Pudełko z Przyjaciółmi,Box of Friends,Box of Friends,Box of Friends,Коробка с друзьями,Cajón de Amigos,Arkadaş Sandığı,Коробка з друзями,Box of Friends,朋友盒,1
+204,Rib of Greed,Rib of Greed,Trinket,그리드의 갈비뼈,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,Rib of Greed,1
+205,Cry Baby,Cry Baby,Other,랜덤 패밀리어,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,Cry Baby,1
+206,Red Baby,Red Baby,Other,랜덤 패밀리어,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,Red Baby,1
+207,Green Baby,Green Baby,Other,랜덤 패밀리어,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,Green Baby,1
+208,Brown Baby,Brown Baby,Other,랜덤 패밀리어,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,Brown Baby,1
+209,Blue Baby,Blue Baby,Other,랜덤 패밀리어,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,Blue Baby,1
+210,Lil' Baby,Lil' Baby,Other,랜덤 패밀리어,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,Lil' Baby,1
+211,Rage Baby,Rage Baby,Other,랜덤 패밀리어,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,Rage Baby,1
+212,Black Baby,Black Baby,Other,랜덤 패밀리어,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,Black Baby,1
+213,Long Baby,Long Baby,Other,랜덤 패밀리어,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,Long Baby,1
+214,Yellow Baby,Yellow Baby,Other,랜덤 패밀리어,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,Yellow Baby,1
+215,White Baby,White Baby,Other,랜덤 패밀리어,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,White Baby,1
+216,Big Baby,Big Baby,Other,랜덤 패밀리어,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,Big Baby,1
+217,Noose Baby,Noose Baby,Other,랜덤 패밀리어,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,Noose Baby,1
+218,Rune Bag,Rune Bag,Item,룬 가방,Торбичка с руни,Pytlíček Run,Runenbeutel,Σάκος Ρουνικών,Rune Bag,Sac de Runes,Sacco di Rune,ルーン袋,Rune Bag,Wór na Runy,Rune Bag,Rune Bag,Rune Bag,Мешочек с рунами,Bolsa de Runas,Rune Kesesi,Мішечок для рун,Rune Bag,符文袋,1
+219,Cambion Conception,Cambion Conception,Item,몽마의 자식들,Демонично зачатие,Početí Kambionu,Cambion Conception,Κακή Σύλληψη,Cambion Conception,Conception Impure,Immorale Concezione,忌血の胎児,Cambion Conception,Poczęcie Kambiona,Cambion Conception,Cambion Conception,Cambion Conception,Зачатие Камбиона,Impura Concepción,Cambion Peydahı,Демонічне зачаття,Cambion Conception,恶魔受胎,1
+220,Serpent's Kiss,Serpent's Kiss,Item,독뱀의 키스,Змийска целувка,Hadí Polibek,Schlangenkuss,Το Φιλί του Φιδιού,Serpent's Kiss,Baiser du Serpent,Bacio del Serpente,サーペントのくちづけ,Serpent's Kiss,Pocałunek Węża,Serpent's Kiss,Serpent's Kiss,Serpent's Kiss,Змеиный поцелуй,Beso de Serpiente,Serpent`in öpücüğü,Зміїний поцілунок,Serpent's Kiss,蛇蝎之吻,1
+221,Succubus,Succubus,Item,서큐버스,Сукуб,Sukubus,Succubus,Χαίρο,Succubus,Succube,Succuba,サキュバス,Succubus,Sukkub,Succubus,Succubus,Succubus,Суккуб,Súcubo,Succubus,Сукуб,Succubus,魅魔,1
+222,Immaculate Conception,Immaculate Conception,Item,원죄없는 잉태,Непорочно зачатие,Neposkvrněné Početí,Immaculate Conception,Αγνή Σύλληψη,Immaculate Conception,Immaculée Conception,Immacolata Concezione,純血の胎児,Immaculate Conception,Niepokalane Poczęcie,Immaculate Conception,Immaculate Conception,Immaculate Conception,Непорочное зачатие,Inmaculada Concepción,Kusursuz Peydah,Непорочне зачаття,Immaculate Conception,圣灵受胎,1
+223,Goat Head Baby,Goat Head Baby,Other,랜덤 패밀리어,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,Goat Head Baby,1
+224,Gold Heart,Gold Heart,Pickup,황금 하트,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,Gold Heart,1
+225,Get out of Jail Free Card,Get out of Jail Free Card,Card,감옥 탈출 카드,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,Get out of Jail Free Card,1
+226,Gold Bomb,Gold Bomb,Pickup,황금 폭탄,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,Gold Bomb,1
+227,2 new pills,"Percs!,Addicted!",Pill,"진통제!,과다복용!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!","Percs!,Addicted!",1
+228,2 new pills,"Re-Lax,???(Amnesia)",Pill,"휴-식,건망증","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)","Re-Lax,???(Amnesia)",1
+229,Poker Chip,Poker Chip,Trinket,포커 칩,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,Poker Chip,1
+230,Stud Finder,Stud Finder,Trinket,벽체 탐지기,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,Stud Finder,1
+231,D8,D8,Item,8면 주사위,D8,D8,D8,Οκτάπλευρο Ζάρι,D8,D8,D8,D8,D8,D8,D8,D8,D8,D8,D8,D8,D8,D8,八面骰,1
+232,Kidney Stone,Kidney Stone,Item,신장 결석,Камък в бъбрека,Ledvinový Kámen,Nierenstein,Νεφρό,Kidney Stone,Calcul Rénal,Calcolo Renale,腎臓結石,Kidney Stone,Kamień Nerkowy,Kidney Stone,Kidney Stone,Kidney Stone,Почечный камень,Piedra de Riñón,Böbrek Taşı,Нирковий камінь,Kidney Stone,肾结石,1
+233,Blank Rune,Blank Rune (Achievement),Rune,비어있는 룬,Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),Blank Rune (Achievement),1
+234,Blue Womb,Blue Womb(Hush),Map,허쉬 루트,Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),Blue Womb(Hush),1
+235,1001%,1001%,None,,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1001%,1
+236,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Other,키퍼가 나무 동전을 가짐,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,Keeper holds Wooden Nickel,1
+237,Keeper holds Store Key,Keeper holds Store Key,Other,키퍼가 상점 키를 가짐,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,Keeper holds Store Key,1
+238,Deep Pockets,Deep Pockets,Item,넓은 가방,Дълбоки джобове,Hluboké Kapsy,Tiefe Taschen,Βαθιές Τσέπες,Deep Pockets,Poches Profondes,Tasche profonde,深いポケット,Deep Pockets,Głębokie Kieszenie,Deep Pockets,Deep Pockets,Deep Pockets,Глубокие карманы,Bolsillos profundos,Derin Cepler,Глибокі кишені,Deep Pockets,深口袋,1
+239,Karma,Karma,Trinket,업보,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,Karma,1
+240,Sticky Nickels,Sticky nickel,Pickup,끈적이 니켈,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,Sticky nickel,1
+241,Super Greed Baby,Super Greed Baby,Other,랜덤 패밀리어,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,Super Greed Baby,1
+242,Lucky Pennies,Lucky penny,Pickup,럭키 페니,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,Lucky penny,1
+243,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Other,매달린 상점주인,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,Special Hanging Shopkeepers,1
+244,Wooden Nickel,Wooden Nickel,Item,나무 동전,Дървен никел,Dřevěný Niklák,Wooden Nickel,Ξύλινη Πεντάρα,Wooden Nickel,Pièce en Bois,Nichelino di Legno,木製硬貨,Wooden Nickel,Drewniany Pieniążek,Wooden Nickel,Wooden Nickel,Wooden Nickel,Деревянный пятак,Moneda de Madera,Ahşap Bozuk Para,Дерев'яний нікель,Wooden Nickel,木制镍币,1
+245,Cain holds Paperclip,Cain holds Paperclip,Other,카인이 종이 클립을 가짐,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,Cain holds Paperclip,1
+246,Everything is Terrible 2!!!,Ultra Greed,Other,울트라 그리드 해금,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,Ultra Greed,1
+247,Special Shopkeepers,Special shopkeeper,Other,상점주인,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,Special shopkeeper,1
+248,Eve now holds Razor Blade,Eve now holds Razor Blade,Other,이브가 면도날을 가짐,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,Eve now holds Razor Blade,1
+249,Store Key,Store Key,Trinket,상점 열쇠,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,Store Key,1
+250,Lost holds Holy Mantle,Lost holds Holy Mantle,Other,로스트가 홀리맨틀을 가짐,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,Lost holds Holy Mantle,1
+251,Keeper,Keeper,Character,키퍼,Keeper,{{CoinHeart}} Uzdravíš se sbíráním mincí#Maximum jsou 3 Mincové srdce#Jakékoliv srdcové pickupy jsou přeměněny na modré mušky#{{DevilRoom}} Ďábelské Dohody stojí 15 nebo 30 mincí,Keeper,Keeper,Keeper,Le Gardien,Keeper,{{CoinHeart}} コインで体力を回復#最大体力は3#ハートは青ハエに 置き換わる#悪魔取引のコストは 15／30コイン,Keeper,Dozorca,Keeper,Keeper,{{CoinHeart}} Heal by picking up coins#Maximum of 2 Coin Hearts#Heart pickups are turned into Blue Flies,Keeper,{{CoinHeart}} Recupera salud recogiendo monedas#Máximo de 2 Corazones Moneda#Convierte los Corazones en moscas azules,Keeper,Keeper,{{CoinHeart}} Hồi máu bằng cách nhặt đồng xu#Tối đa 3 Trái tim xu#Trái tim nhặt biến thành Ruồi xanh#{{DevilRoom}} Giao kèo quỷ tốn 15 hoặc 30 đồng xu,Keeper,1
+252,Hive Baby,Hive Baby,Other,랜덤 패밀리어,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,Hive Baby,1
+253,Buddy Baby,Buddy Baby,Other,랜덤 패밀리어,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,Buddy Baby,1
+254,Colorful Baby,Colorful Baby,Other,랜덤 패밀리어,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,Colorful Baby,1
+255,Whore Baby,Whore Baby,Other,랜덤 패밀리어,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,Whore Baby,1
+256,Cracked Baby,Cracked Baby,Other,랜덤 패밀리어,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,Cracked Baby,1
+257,Dripping Baby,Dripping Baby,Other,랜덤 패밀리어,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,Dripping Baby,1
+258,Blinding Baby,Blinding Baby,Other,랜덤 패밀리어,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,Blinding Baby,1
+259,Sucky Baby,Sucky Baby,Other,랜덤 패밀리어,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,Sucky Baby,1
+260,Dark Baby,Dark Baby,Other,랜덤 패밀리어,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,Dark Baby,1
+261,Picky Baby,Picky Baby,Other,랜덤 패밀리어,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,Picky Baby,1
+262,Revenge Baby,Revenge Baby,Other,랜덤 패밀리어,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,Revenge Baby,1
+263,Belial Baby,Belial Baby,Other,랜덤 패밀리어,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,Belial Baby,1
+264,Sale Baby,Sale Baby,Other,랜덤 패밀리어,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,Sale Baby,1
+265,XXXXXXXXL,XXXXXXXXL,None,챌린지 21,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,XXXXXXXXL,1
+266,SPEED!,SPEED!,None,챌린지 22,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,SPEED!,1
+267,Blue Bomber,Blue Bomber,None,챌린지 23,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,Blue Bomber,1
+268,PAY TO PLAY,PAY TO PLAY,None,챌린지 24,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,PAY TO PLAY,1
+269,Have a Heart,Have a Heart,None,챌린지 25,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,Have a Heart,1
+270,I RULE!,I RULE!,None,챌린지 26,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,I RULE!,1
+271,BRAINS!,BRAINS!,None,챌린지 27,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,BRAINS!,1
+272,PRIDE DAY!,PRIDE DAY!,None,챌린지 28,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,PRIDE DAY!,1
+273,Onan's Streak,Onan's Streak,None,챌린지 29,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,Onan's Streak,1
+274,The Guardian,The Guardian,None,챌린지 30,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,The Guardian,1
+275,Generosity,Generosity,None,,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,Generosity,1
+276,Mega,Mega Blast,Item,메가 블래스트,Мега Заряд,Mega Výstřel,Mega Blast,Υπερφύσημα,Mega Blast,Souffle du Diable,Mega Sbotto,メガブラスト,Mega Blast,Mega Strzał,Mega Blast,Mega Blast,Mega Blast,Мега заряд,Mega Ráfaga,Mega Atış,Мегазаряд,Mega Blast,超级喷射,1
+277,Backasswards,Backasswards,Other,챌린지 해금,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,Backasswards,1
+278,Aprils fool,Aprils Fool,Other,챌린지 해금,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,Aprils Fool,1
+279,Pokey Mans,Pokey Mans,Other,챌린지 해금,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,Pokey Mans,1
+280,Ultra Hard,Ultra Hard,Other,챌린지 해금,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,Ultra Hard,1
+281,PONG,Pong,Other,챌린지 해금,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,Pong,1
+282,D Infinity,D infinity,Item,무한 주사위,D-безкрайност,D Nekonečno,D Unendlichkeit,Άπειρο Ζάρι,D infinity,Dé Infini,D Infinito,Ｄインフィニティー,D Infinity,D Nieskończoność,D infinity,D infinity,D Infinity,D Бесконечность,D infinito,D Sonsuzluk,D Безмежність,D Infinity,无限面骰,1
+283,Eucharist,Eucharist,Item,성찬,Причастие,Eucharistie,Eucharist,Ευχαριστία,Eucharist,Eucharistie,Eucaristia,エウカリスト,Eucharist,Eucharystia,Eucharist,Eucharist,Eucharist,Причастие,Eucaristía,Ayin,Євхаристія,Eucharist,圣餐,1
+284,Silver Dollar,Silver Dollar,Trinket,은화,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,Silver Dollar,1
+285,Shade,Shade,Item,셰이드,Сянка,Stínovač,Schatten,Απόχρωση,Shade,Ombre,Ombroso,シェード,Shade,Cień,Shade,Shade,Shade,Тень,Sombra,Gölge,Тінь,Shade,阴影,1
+286,King Baby,King Baby,Item,아기 왕,Бебе крал,Královské Dítě,Königsbaby,Μωρό Βασιλίας,King Baby,Bébé Roi,Re Bebè,キングベイビー,King Baby,Dziecięcy Król,King Baby,King Baby,King Baby,Малыш король,Rey bebé,Kral Bebek,Дитя Король,King Baby,国王宝宝,1
+287,Bloody Crown,Bloody Crown,Trinket,피투성이 왕관,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,Bloody Crown,1
+288,Dull Razor,Dull Razor,Item,무딘 면도칼,Тъп бръснач,Tupá Žiletka,Dull Razor,Αμβλύ Ξυράφι,Dull Razor,Lame Émoussée,Lametta Smussata,切れ味の鈍いカミソリ,Dull Razor,Tępa Żyletka,Dull Razor,Dull Razor,Dull Razor,Тупая бритва,Hoja sin Filo,Kör Jilet,Тупе лезо,Dull Razor,钝剃刀片,1
+289,Eden's Soul,Eden's Soul,Item,에덴의 영혼,Душата на Едем,Edenova Duše,Eden's Soul,Η Ψυχί του Εδέμ,Eden's Soul,Âme d'Éden,Anima di Eden,エデンの魂,Eden's Soul,Dusza Edena,Eden's Soul,Eden's Soul,Eden's Soul,Душа Эдема,Alma de Edén,Eden'in Ruhu,Едемова душа,Eden's Soul,伊甸的灵魂,1
+290,Dark Prince's Crown,Dark Prince's Crown,Item,어둠 왕자의 왕관,Короната на тъмния принц,Koruna Temného Prince,Krone des Dunklen Prinzen,Το Στέμμα του Σκοτεινού Πρίγκιπα,Dark Prince's Crown,Couronne des Ténèbres,Corona del Principe delle Tenebre,ダークプリンスの冠,Dark Prince's Crown,Korona Księcia Mroku,Dark Prince's Crown,Dark Prince's Crown,Dark Prince's Crown,Корона тёмного принца,Corona del Príncipe Oscuro,Kara Prenses Tacı,Корона Темного Принца,Dark Prince's Crown,黑王子之冠,1
+291,Compound Fracture,Compound Fracture,Item,복합 골절,Отворена фрактура,Otevřená Zlomenina,Knochenbruch,Σύνθετο Κάταγμα,Compound Fracture,Fracture Ouverte,Frattura Esposta,複雑骨折,Compound Fracture,Złamanie Otwarte,Compound Fracture,Compound Fracture,Compound Fracture,Перелом,Fractura Compuesta,Derin Çatlama,Перелом,Compound Fracture,复杂性骨折,1
+292,Euthanasia,Euthanasia,Item,안락사,Евтаназия,Eutanázie,Euthanasie,Ευθανασία,Euthanasia,Euthanasie,Eutanasia,安楽死,Euthanasia,Eutanazja,Euthanasia,Euthanasia,Euthanasia,Эвтаназия,Eutanasia,Ötenazi,Евтаназія,Euthanasia,安乐死,1
+293,Holy Card,Holy Card,Card,신성한 카드,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,Holy Card,1
+294,Crooked Penny,Crooked Penny,Item,구부러진 동전,Изкривено пени,Pokřivená Mince,Crooked Penny,Στραβό Λεπτό,Crooked Penny,Pièce Tordue,Penny Storto,曲がったペニー,Crooked Penny,Skrzywiony Pieniążek,Crooked Penny,Crooked Penny,Crooked Penny,Погнутый пенни,Moneda Doblada,Yamuk Para,Зігнутий пенні,Crooked Penny,被掰弯的硬币,1
+295,Void,Void,Item,공허,Пустота,Prázdnota,Leere,Κενό,Void,Néant,Vuoto,ボイド,Void,Pustka,Void,Void,Void,Пустота,Vacío,Boşluk,Порожнеча,Void,虚空,1
+296,D1,D1,Item,1면 주사위,D1,D1,D1,Μονόπλευρο Ζάρι,D1,D1,D1,D1,D1,D1,D1,D1,D1,D1,D1,D1,D1,D1,一面骰,1
+297,Glyph of Balance,Glyph of Balance,Item,균형의 문장,Символ за баланс,Symbol Rovnováhy,Glyphe des Gleichgewichts,Γλύφος της Ισορροπίας,Glyph of Balance,Marque d'Harmonie,Glifo dell'Equilibrio,バランスのグリフ,Glyph of Balance,Glif Równowagi,Glyph of Balance,Glyph of Balance,Glyph of Balance,Символ баланса,Glifo del equilibrio,Denge Sembolü,Гліф рівноваги,Glyph of Balance,平衡符号,1
+298,Sack of Sacks,Sack of Sacks,Item,자루 주머니,Торбичка с торбички,Pytel Pytlů,Sack of Sacks,Σάκος των Σάκων,Sack of Sacks,Sac de Sacs,Sacco di Sacchi,袋の中の袋,Sack of Sacks,Sakiewka na Sakiewki,Sack of Sacks,Sack of Sacks,Sack of Sacks,Мешок мешков,Bolsa de Bolsas,Kese Kesesi,Мішечок монет,Sack of Sacks,袋中袋,1
+299,Eye of Belial,Eye of Belial,Item,벨리알의 눈,Окото на Белиал,Oko Belialovo,Auge von Belial,Μάτι του Μπελιάλ,Eye of Belial,Œil de Bélial,Occhio di Belial,ベリアルの目,Eye of Belial,Oko Beliala,Eye of Belial,Eye of Belial,Eye of Belial,Глаз Белиала,Ojo de Belial,Belialın Gözü,Око Беліала,Eye of Belial,彼列之眼,1
+300,Meconium,Meconium,Trinket,태변,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,Meconium,1
+301,Stem Cell,Stem Cell,Trinket,줄기 세포,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,Stem Cell,1
+302,Crow Heart,Crow Heart,Trinket,까마귀 심장,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,Crow Heart,1
+303,Metronome,Metronome,Item,메트로놈,Метроном,Metronom,Metronome,Μετρονόμος,Metronome,Métronome,Metronomo,メトロノーム,Metronome,Metronom,Metronome,Metronome,Metronome,Метроном,Metrónomo,Metronom,Метроном,Metronome,节拍器,1
+304,Bat Wing,Bat Wing,Trinket,박쥐 날개,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,Bat Wing,1
+305,Plan C,Plan C,Item,플랜 C,План C,Plán C,Plan C,Σχέδιο Γ,Plan C,Suppo de Satan,Piano C,プランＣ,Plan C,Plan C,Plan C,Plan C,Plan C,План C,Plan C,Plan C,План C,Plan C,计划C,1
+306,Duality,Duality,Item,이중성,Двойственост,Dualita,Duality,Δυαμότης,Duality,Dualité,Dualismo,二重性,Duality,Dualizm,Duality,Duality,Duality,Двойственность,Dualidad,Dualite,Подвійність,Duality,二元性,1
+307,Dad's Lost Coin,Dad's Lost Coin,Item,아빠의 잃어버린 동전,Изгубената монета на татко,Tátova Ztracená Mince,Papas Verlorenes Geld,Το Χαμένο Κέρμα του Μπαμπά,Dad's Lost Coin,Médaille de Papa,Moneta Perduta di Papà,パパが失くしたコイン,Dad's Lost Coin,Zgubiona Moneta Taty,Dad's Lost Coin,Dad's Lost Coin,Dad's Lost Coin,Папина потерянная монета,Moneda perdida de Papá,Babanın Kayıp Bozuk Parası,Татусева втрачена монета,Dad's Lost Coin,爸爸丢失的硬币,1
+308,Eye of Greed,Eye of Greed,Item,탐욕의 눈,Окото на Алчността,Greedovo Oko,Auge der Gier,Μάτι της Απληστίας,Eye of Greed,Œil d'Avarice,Occhio di Avarizia,グリードの目,Eye of Greed,Chciwe Oko,Eye of Greed,Eye of Greed,Eye of Greed,Глаз Алчности,Ojo de Codicia,Greedin gözü,Око Жадібності,Eye of Greed,贪婪的眼睛,1
+309,Black Rune,Black Rune,Rune,검은 룬,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,Black Rune,1
+310,Locust of Wrath,Locust of War,Trinket,전쟁의 메뚜기,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,Locust of War,1
+311,Locust of Pestilence,Locust of Pestilence,Trinket,역병의 메뚜기,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,Locust of Pestilence,1
+312,Locust of Famine,Locust of Famine,Trinket,기근의 메뚜기,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,Locust of Famine,1
+313,Locust of Death,Locust of Death,Trinket,죽음의 메뚜기,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,Locust of Death,1
+314,Locust of Conquest,Locust of Conquest,Trinket,정복의 메뚜기,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,Locust of Conquest,1
+315,Hushy,Hushy,Item,허쉬,Хъши,Hushy,Hushy,Σιωπηλούλης,Hushy,P'tit Murmure,Calmina,ハッシー,Hushy,Hushy,Hushy,Hushy,Hushy,Молчун,Shhh,Hushy,Мовчун,Hushy,死寂宝宝,1
+316,Brown Nugget,Brown Nugget,Item,갈색 너겟,Кафяво късче,Hnědý Nuget,Braune Pepitas,Καφέ Όγκος,Brown Nugget,Bout de Crotte,Pepita Marrone,ブラウンナゲット,Brown Nugget,Brązowy Bobek,Brown Nugget,Brown Nugget,Brown Nugget,Коричневый самородок,Nugget café,Kahverengi Nugget,Коричневий самородок,Brown Nugget,棕色粪块,1
+317,Mort Baby,Mort Baby,Other,랜덤 패밀리어,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,Mort Baby,1
+318,Smelter,Smelter,Item,용광로,Леярна,Tavící Pec,Smelter,Χυτήριο,Smelter,Fondeuse,Fonderia,スメルター,Smelter,Wytapiacz,Smelter,Smelter,Smelter,Плавильня,Fundidora,Eritici,Плавильня,Smelter,熔炉,1
+319,Apollyon Baby,Apollyon Baby,Other,랜덤 패밀리어,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,Apollyon Baby,1
+320,New Area,The Void,Map,공허,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,The Void,1
+321,Once More with Feeling!,Gulp!,Pill,꿀꺽!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,Gulp!,1
+322,Hat trick!,Ace of Clubs,Card,클로버 A,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,Ace of Clubs,1
+323,5 Nights at Mom's,Super special rock,Other,슈퍼색돌 등장,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,Super special rock,1
+324,Sin collector,Feels Like I'm Walking on Sunshine!,Pill,햇살 위를 걷는 기분이야!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,Feels Like I'm Walking on Sunshine!,1
+325,Dedication,Horf!,Pill,퉤엣!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,Horf!,1
+326,ZIP!,Ace of Diamonds,Card,다이아 A,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,Ace of Diamonds,1
+327,It's the Key,Ace of Spades,Card,스페이드 A,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,Ace of Spades,1
+328,Mr. Resetter!,Scared Heart,Pickup,도망가는 하트,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,Scared Heart,1
+329,Living on the edge,Ace of Hearts,Card,하트 A,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,Ace of Hearts,1
+330,U Broke It!,Vurp!,Pill,끄어억!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,Vurp!,1
+331,Laz Bleeds More!,Laz Bleeds More!,Other,나사로가 빈혈증을 가짐,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,Laz Bleeds More!,1
+332,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Other,막달레나가 체력회복 알약을 가짐,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,Maggy Now Holds a Pill!,1
+333,Charged Key,Charged Key,Pickup,액티브 충전 열쇠,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,Charged Key,1
+334,Samson Feels Healthy!,Samson Feels Healthy!,Other,삼손이 피의 욕망을 가짐,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,Samson Feels Healthy!,1
+335,Greed's Gullet,Greed's Gullet,Item,탐욕의 식도,Торбичка на Алчността,Greedův Jícen,Gier-Magen,Οισοφάγος της Απληστίας,Greed's Gullet,Gosier d'Avarice,Gozzo di Avarizia,グリードの喉,Greed's Gullet,Przełyk Chciwości,Greed's Gullet,Greed's Gullet,Greed's Gullet,Пищевод Алчности,Esófago de Codicia,Greed'in Boğazı,Стравохід Жадібності,Greed's Gullet,贪婪的胃袋,1
+336,The Marathon,Cracked Crown,Trinket,금이 간 왕관,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,Cracked Crown,1
+337,RERUN,RERUN,Other,재도전 모드 해금,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,RERUN,1
+338,Delirious,Delirious,Item,정신착란,Бълнуващ,Blouznivec,Im Delirium,Παραληρών,Delirious,Délire,Delirante,精神錯乱,Delirious,Delirious,Delirious,Delirious,Delirious,Бредящий,Delirious,Delirious,Несамовитий,Delirious,精神错乱,1
+339,1000000%,1000000%,None,,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1000000%,1
+340,Apollyon,Apollyon,Character,아폴리온,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apollyon,Apolión,Apollyon,Apollyon,Apollyon,Apollyon,1
+341,Greedier!,Greedier Mode,Other,그리디어 모드 해금,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,Greedier Mode,1
+342,Burning Basement,Burning Basement,Map,불타는 지하실,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,Burning Basement,1
+343,Flooded Caves,Flooded Caves,Map,,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,Flooded Caves,1
+344,Dank Depths,Dank Depths,Map,,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,Dank Depths,1
+345,Scarred Womb,Scarred Womb,Map,,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,Scarred Womb,1
+346,Something wicked this way comes!,Little Horn,Boss,작은 뿔,Малкия рог,Malej Horn,Kleines Horn,Μικρό Κέρατο,Little Horn,P'tite Corne,Piccolo Corno,リトルホーン,Little Horn,Mały Róg,Little Horn,Little Horn,Little Horn,Маленький рог,Cuernito,Minik Horn,Маленький ріг,Little Horn,小魔角,1
+347,Something wicked this way comes+!,Big Horn,Boss,큰 뿔,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,Big Horn,1
+348,The gate is open!,Portal,Other,Portal 몬스터 해금(보이드 포탈),Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,Portal,1
+349,Black Hole,Black Hole,Item,블랙홀,Черна дупка,Černá Díra,Black Hole,Μαύρη Τρύπα,Black Hole,Trou Noir,Buco Nero,ブラックホール,Black Hole,Czarna Dziura,Black Hole,Black Hole,Black Hole,Чёрная дыра,Agujero negro,Kara Delik,Чорна діра,Black Hole,黑洞,1
+350,Mystery Gift,Mystery Gift,Item,수수께끼의 선물,Тайнствен подарък,Tajemný Dárek,Mystery Gift,Μυστηριώδες Δώρο,Mystery Gift,Cadeau Surprise,Dono Segreto,ミステリーギフト,Mystery Gift,Tajemniczy Prezent,Mystery Gift,Mystery Gift,Mystery Gift,Загадочный подарок,Regalo misterioso,Gizemli Hediye,Загадковий подарунок,Mystery Gift,神秘礼物,1
+351,Sprinkler,Sprinkler,Item,스프링클러,Пръскачка,Rozstřikovač,Sprinkler,Ψεκαστήρας,Sprinkler,Arroseur Automatique,Irrigatore,スプリンクラー,Sprinkler,Zraszacz,Sprinkler,Sprinkler,Sprinkler,Ороситель,Aspersor,Sulayıcı,Зрошувач,Sprinkler,洒水器,1
+352,Angry Fly,Angry Fly,Item,성난 파리,Ядосана муха,Naštvaná Moucha,Angry Fly,Θυμωμένη Μύγα,Angry Fly,Mouche Enragée,Moscarrabbiata,怒ったハエ,Angry Fly,Wściekła Mucha,Angry Fly,Angry Fly,Angry Fly,Сердитая муха,Mosca Enojada,Kızgın Sinek,Розлючена муха,Angry Fly,愤怒苍蝇,1
+353,Bozo,Bozo,Item,멍청이,Бозо,Klaun Bozo,Bozo,Βόζο,Bozo,Bozo,Pagliaccio,ボゾ,Bozo,Bozo,Bozo,Bozo,Bozo,Бозо,Bozo,Bozo,Бозо,Bozo,派对帽,1
+354,Broken Modem,Broken Modem,Item,고장난 모뎀,Счупен модем,Rozbitý Modem,Kaputtes Modem,Χαλασμένο Μόντεμ,Broken Modem,Routeur Cassé,Modem Sfasciato,壊れたモデム,Broken Modem,Zepsuty Modem,Broken Modem,Broken Modem,Broken Modem,Сломанный модем,Modem Roto,Bozuk Modem,Зламаний модем,Broken Modem,损坏的调制解调器,1
+355,Buddy in a Box,Buddy in a Box,Item,친구 든 상자,Приятел в кутия,Kamarád v Bedně,Buddy in a Box,Φίλος σε Κουτί,Buddy in a Box,Pote en Boîte,Amico in Scatola,箱の中のバディー,Buddy in a Box,Kumpel z Pudełka,Buddy in a Box,Buddy in a Box,Buddy in a Box,Друг в коробке,Compañero Encajonado,Kutuda Arkadaş,Друзяка в коробці,Buddy in a Box,伙伴盲盒,1
+356,Fast Bombs,Fast Bombs,Item,빠른 폭탄,Бързи бомби,Rychlo-Bomby,Schnellbomben,Γρήγορες Βόμβες,Fast Bombs,Bombes Éclair,Bombe Leste,ファスト ボム,Fast Bombs,Szybkie Bomby,Fast Bombs,Fast Bombs,Fast Bombs,Быстрые бомбы,Bombas Rápidas,Hızlı Bombalar,Швидкі бомби,Fast Bombs,快速炸弹,1
+357,Lil Delirium,Lil Delirium,Item,꼬마 델리리움,Малката лудост,Maličký Delirium,Lil Delirium,Μικρούλης Παραληρμένος,Lil Delirium,P'tit Delirium,Mini Delirio,リトルデリリアム,Lil Delirium,Tyci Delirium,Lil Delirium,Lil Delirium,Lil Delirium,Малютка Сумасшествие,Mini-Delirio,Minik Delirium,Крихітка Делліріум,Lil Delirium,精神错乱宝宝,1
+358,Hairpin,Hairpin,Trinket,머리핀,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,Hairpin,1
+359,Wooden Cross,Wooden Cross,Trinket,나무 십자가,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,Wooden Cross,1
+360,Butter!,Butter!,Trinket,버터!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,Butter!,1
+361,Huge Growth,Huge Growth,Card,거대한 성장,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,Huge Growth,1
+362,Ancient Recall,Ancient Recall,Card,고대의 부름,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,Ancient Recall,1
+363,Era Walk,Era Walk,Card,시간 여행,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,Era Walk,1
+364,Coupon,Coupon,Item,쿠폰,Купон,Kupón,Coupon,Κουπόνι,Coupon,Coupon,Coupon,クーポン,Coupon,Kupon,Coupon,Coupon,Coupon,Купон,Cupón,Kupon,Купон,Coupon,代金券,1
+365,Telekinesis,Telekinesis,Item,염동력,Телекинеза,Telekineze,Telekinesis,Τηλεκινησία,Telekinesis,Télékinésie,Telecinesi,テレキネシス,Telekinesis,Telekineza,Telekinesis,Telekinesis,Telekinesis,Телепатия,Telequinesia,Telekinezi,Телекінез,Telekinesis,念力,1
+366,Moving Box,Moving Box,Item,수납상자,Кутия за доставка,Stěhovací Krabice,Umzugskarton,Κουτί Μετακινήσεων,Moving Box,Carton de Déménagement,Scatola per Traslochi,お引越し用の箱,Moving Box,Pudło na Przenosiny,Moving Box,Moving Box,Moving Box,Коробка для перевозки,Caja de mudanza,Taşınma Kolisi,Коробка для перенесень,Moving Box,搬家盒,1
+367,Jumper Cables,Jumper Cables,Item,점퍼 케이블,Кабели за стартов ток,Startovací Kabely,Jumper Cables,Καλώδια Βραχυκύκλωσης,Jumper Cables,Câbles de Démarrage,Morsetti,ブースターケーブル,Jumper Cables,Kable Rozruchowe,Jumper Cables,Jumper Cables,Jumper Cables,Соединительные кабели,Cables de Salto,Akü Kablosu,Кабель-перемичка,Jumper Cables,跨接电缆,1
+368,Leprosy,Leprosy,Item,문둥병,Проказа,Lepra,Leprosy,Λέπρα,Leprosy,Lèpre,Lebbra,レプロシー,Leprosy,Trąd,Leprosy,Leprosy,Leprosy,Проказа,Lepra,Cüzam,Проказа,Leprosy,麻风病,1
+369,Technology Zero,Technology Zero,Item,기계장치 0,Технология Нула,Technologie Nula,Technologie Null,Τεχνολογία Μηδέν,Technology Zero,Technologie Zéro,Tecnologia Zero,テクノロジーゼロ,Technology Zero,Technologia Zero,Technology Zero,Technology Zero,Technology Zero,Технология Ноль,Tecnología Cero,Teknoloji 00,Технологія Нуль,Technology Zero,科技零,1
+370,Filigree Feather,Filigree Feather,Trinket,세공 깃털,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,Filigree Feather,1
+371,Mr. ME!,Mr. ME!,Item,미 씨!,Мистър МИ!,Pan JÁ!,Mr. ME!,Κύριος ΕΓΩ!,Mr. ME!,Boîte à Larbin,Mr. GUARDI!,ミスターボク！,Mr. ME!,Pan JA!,Mr. ME!,Mr. ME!,Mr. ME!,Мистер Ми!,¡Sr. YO!,Mr. ME!,Містер Я!,Mr. ME!,自我先生！,1
+372,7 Seals,7 Seals,Item,7개의 도장,7 печата,7 Pečetí,7 Seals,7 Σφραγίδες,7 Seals,Livre des 7 Sceaux,7 Sigilli,７つの封印,7 Seals,7 Pieczęci,7 Seals,7 Seals,7 Seals,7 печатей,Los 7 Sellos,7 Atlı,7 Печаток,7 Seals,七印,1
+373,Angelic Prism,Angelic Prism,Item,천사빛 프리즘,Ангелска призма,Andělský Hranol,Angelic Prism,Αγγελικό Πρίσμα,Angelic Prism,Prisme Angélique,Prisma Angelico,エンジェリック プリズム,Angelic Prism,Anielski Pryzmat,Angelic Prism,Angelic Prism,Angelic Prism,Ангельская призма,Prisma angelical,Melek Prizması,Ангельська призма,Angelic Prism,天使棱镜,1
+374,Pop!,Pop!,Item,뽁!,Пук!,Plup!,Pop!,Ποπ!,Pop!,Pop !,Pop!,ポロッ！,Pop!,Pop!,Pop!,Pop!,Pop!,Хлоп!,¡Pop!,Pop!,Хлюп!,Pop!,噗！,1
+375,Door Stop,Door Stop,Trinket,문 받침대,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,Door Stop,1
+376,Death's List,Death's List,Item,죽음의 살생부,Списък на смъртта,Seznam Smrti,Death's List,Λίστα του Θανάτου,Death's List,La Liste de la Mort,Lista Nera,死神のリスト,Death's List,Lista Śmierci,Death's List,Death's List,Death's List,Список смерти,Lista de la muerte,Azrailin Listesi,Список смерті,Death's List,死神名册,1
+377,Haemolacria,Haemolacria,Item,피눈물병,Хемолакрия,Hemolakrie,Hämolyse,Αιμολακρία,Haemolacria,Haemolacria,Emolacria,流血,Haemolacria,Hemolakria,Haemolacria,Haemolacria,Haemolacria,Гемолакрия,Hemolacria,Kan Gözyaşı,Гемолакрія,Haemolacria,泪血症,1
+378,Lachryphagy,Lachryphagy,Item,눈물먹이,Лакрифагия,Lachryfagie,Lachryphagy,Λαχρυφία,Lachryphagy,Lachryphagie,Lacrifagia,涙ごっくん,Lachryphagy,Wygłodniałe Łzy,Lachryphagy,Lachryphagy,Lachryphagy,Лакрифагия,Lacrifagia,Lachryphagy,Сльозотеча,Lachryphagy,食泪症,1
+379,Schoolbag,Schoolbag,Item,책가방,Ученическа раница,Školní Aktovka,Schoolbag,Σχολική Τσάντα,Schoolbag,Cartable,Zainetto,スクール バッグ,Schoolbag,Plecak Szkolny,Schoolbag,Schoolbag,Schoolbag,Школьный портфель,Mochila,Okul Çantası,Рюкзак,Schoolbag,书包,1
+380,Trisagion,Trisagion,Item,삼성송,Трисвятост,Trisagion,Trisagion,Τρισάγιο,Trisagion,Trisagion,Trisagion,聖三祝文,Trisagion,Trisagion,Trisagion,Trisagion,Trisagion,Трисвятое,Trisagio,Trisagion,Трисвяте,Trisagion,三圣颂,1
+381,Extension Cord,Extension Cord,Trinket,연장 코드,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,Extension Cord,1
+382,Flat Stone,Flat Stone,Item,납작한 돌,Плосък камък,Plochý Kámen,Flat Stone,Επίπεδη Πέτρα,Flat Stone,Pierre Plate,Sasso Piatto,フラットストーン,Flat Stone,Płaski Kamień,Flat Stone,Flat Stone,Flat Stone,Плоский камень,Piedra plana,Düz Taş,Плаский камінь,Flat Stone,扁石,1
+383,Sacrificial Altar,Sacrificial Altar,Item,희생의 제단,Жертвен олтар,Obětní Oltář,Sacrificial Altar,Θυσιαστικός Βωμός,Sacrificial Altar,Autel Sacrificiel,Altare Sacrificale,いけにえの祭壇,Sacrificial Altar,Ołtarz Ofiarny,Sacrificial Altar,Sacrificial Altar,Sacrificial Altar,Жертвенный алтарь,Altar de sacrificio,Kurban Alanı,Вівтар для жертвопринесень,Sacrificial Altar,祭坛,1
+384,Lil Spewer,Lil Spewer,Item,꼬마 구토쟁이,Малкият плювач,Maličký Plivač,Lil Spewer,Μικρούλης Χτύπος,Lil Spewer,P'tit Spewer,Mini Conato,リトルゲロゲロ,Lil Spewer,Tyci Spewer,Lil Spewer,Lil Spewer,Lil Spewer,Маленький Спевер,Mini-vómitos,Minik Tükürücü,Крихітка Ригачка,Lil Spewer,呕吐虫宝宝,1
+385,Blanket,Blanket,Item,담요,Одеяло,Přikrývka,Blanket,Κουβέρτα,Blanket,Couverture,Copertina,もうふ,Blanket,Kocyk,Blanket,Blanket,Blanket,Одеяло,Manto,Battaniye,Ковдра,Blanket,毛毯,1
+386,Marbles,Marbles,Item,구슬,Стъклени топчета,Kuličky,Marbles,Μπίλιες,Marbles,Sac de Billes,Biglie,ビー玉,Marbles,Marmurki,Marbles,Marbles,Marbles,Шарики,Canicas,Bilyeler,Камінці,Marbles,弹珠袋,1
+387,Mystery Egg,Mystery Egg,Item,이상한 알,Тайнствено яйце,Tajemné Vejce,Mystery Egg,Μυστηριώδες Αυγό,Mystery Egg,Œuf Mystère,Uovo Misterioso,ミステリーエッグ,Mystery Egg,Jajko Niespodzianka,Mystery Egg,Mystery Egg,Mystery Egg,Загадочное яйцо,Huevo misterioso,Gizemli Yumurta,Загадкове яйце,Mystery Egg,神秘的卵,1
+388,Rotten Penny,Rotten Penny,Trinket,썩은 동전,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,Rotten Penny,1
+389,Baby-Bender,Baby-Bender,Trinket,아기 초능력자,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,Baby-Bender,1
+390,The Forgotten,The Forgotten,Character,포가튼,The Forgotten,The Forgotten,The Forgotten,The Forgotten,The Forgotten,Le Délaissé,The Forgotten,The Forgotten,The Forgotten,Zapomniany,The Forgotten,The Forgotten,You have a melee attack which can be charged and thrown#{{BoneHeart}} Can have up to 6 Bone Hearts#{{Player17}} Press {{ButtonRT}} to switch to The Soul#{{SoulHeart}} The Soul can have up to 6 Soul/Black Hearts and has flight and spectral tears#The Soul is chained to a small radius around The Forgotten,The Forgotten,El Olvidado,The Forgotten,The Forgotten,The Forgotten,The Forgotten,1
+391,Bone Heart,Bone Heart,Pickup,뼈하트,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,Bone Heart,1
+392,Marrow,Marrow,Item,골수,Костен мозък,Kostní Dřeň,Marrow,Μυελός Οστέων,Marrow,Moelle,Midollo,髄,Marrow,Szpik,Marrow,Marrow,Marrow,Костный мозг,Médula,İlik,Кістковий мозок,Marrow,骨髓,1
+393,Slipped Rib,Slipped Rib,Item,빠진 갈비뼈,Ставно ребро,Vyklouzlé Žebro,Slipped Rib,Γλιστρημένο Πλευρό,Slipped Rib,Côte Cassée,Costola Fluttuante,すべり肋骨,Slipped Rib,Przesunięte Żebro,Slipped Rib,Slipped Rib,Slipped Rib,Скользящее ребро,Costilla deslizante,Kaygan Pirzola,Зміщене ребро,Slipped Rib,滑肋骨,1
+394,Pointy Rib,Pointy Rib,Item,날카로운 갈비뼈,Наточено ребро,Špičaté Žebro,Pointy Rib,Μυτερό Πλευρό,Pointy Rib,Côte Pointue,Costola Appuntita,トゲトゲあばら骨,Pointy Rib,Spiczaste Żebro,Pointy Rib,Pointy Rib,Pointy Rib,Заострённое ребро,Costilla con Punta,Sivri Pirzola,Загострене ребро,Pointy Rib,尖肋骨,1
+395,Jaw Bone,Jaw Bone,Item,턱뼈,Челюстна кост,Čelistní Kost,Jaw Bone,Κόκκαλο Σαγονιού,Jaw Bone,Mandibule,Mandibola,あご骨,Jaw Bone,Szczęka,Jaw Bone,Jaw Bone,Jaw Bone,Челюстная кость,Hueso de Mandíbula,Çene Kemiği,Щелепна кістка,Jaw Bone,颌骨,1
+396,Brittle Bones,Brittle Bones,Item,최약골,Крехки кости,Křehké Kosti,Brüchige Knochen,Εύθραυστα Κόκκαλα,Brittle Bones,Os de Verre,Osteogenesi Imperfetta,脆弱骨,Brittle Bones,Łamliwe Kości,Brittle Bones,Brittle Bones,Brittle Bones,Хрупкие кости,Huesos frágiles,Kırılgan Kemikler,Крихкі кістки,Brittle Bones,脆骨症,1
+397,Divorce Papers,Divorce Papers,Item,이혼 서류,Документи за развод,Rozvodové Papíry,Divorce Papers,Χαρτιά Διαζυγίου,Divorce Papers,Acte de Divorce,Documenti per il Divorzio,離婚届,Divorce Papers,Papiery Rozwodowe,Divorce Papers,Divorce Papers,Divorce Papers,Бумаги о разводе,Papeles del divorcio,Boşanma Belgeleri,Документи про розлучення,Divorce Papers,离婚协议书,1
+398,Hallowed Ground,Hallowed Ground,Item,성지,Света земя,Posvátné Hovno,Heiliger Boden,Ιεροσωμένο Εδαφος,Hallowed Ground,Terre sacrée,Terra Consacrata,神聖なる土,Hallowed Ground,Poświęcona Ziemia,Hallowed Ground,Hallowed Ground,Hallowed Ground,Священная земля,Suelo Santificado,Çukur,Свята земля,Hallowed Ground,圣地大便,1
+399,Finger Bone,Finger Bone,Trinket,손가락 뼈,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,Finger Bone,1
+400,Dad's Ring,Dad's Ring,Item,아빠의 반지,Пръстенът на татко,Tátův Prsten,Dad's Ring,Το Δαχτυλίδι του Μπαμπά,Dad's Ring,Bague de Papa,Anello di Papà,パパのゆびわ,Dad's Ring,Pierścień Taty,Dad's Ring,Dad's Ring,Dad's Ring,Отцовское кольцо,Anillo de papá,Babanın Yüzüğü,Татусеве кільце,Dad's Ring,爸爸的戒指,1
+401,Book of the Dead,Book of the Dead,Item,망자의 책,Книга на мъртвите,Kniha Mrtvých,Book of the Dead,Το Βιβλίο των Νεκρών,Book of the Dead,Livre des Morts,Libro dei Morti,死者の本,Book of the Dead,Księga Umarłych,Book of the Dead,Book of the Dead,Book of the Dead,Книга мёртвых,Libro de los Muertos,Ölülerin Kitabı,Книга Мертвих,Book of the Dead,亡者之书,1
+402,Bone Baby,Bone Baby,Other,랜덤 패밀리어,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,Bone Baby,1
+403,Bound Baby,Bound Baby,Other,랜덤 패밀리어,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,Bound Baby,1
+404,Bethany,Bethany,Character,베서니,Bethany,{{SoulHeart}} Použij Duševní srdce k nabití aktivního předmětu#Duševní srdce nelze použít jako zdraví,Bethany,Bethany,Bethany,Béthanie,Bethany,青／黒ハートを体力へ 追加できない代わりに、 アクティブアイテムの チャージとして使用できる,Bethany,Betania,Bethany,Bethany,{{SoulHeart}} Use Soul Hearts to charge your active item#Can't use Soul Hearts as health,Bethany,{{SoulHeart}} Utiliza los corazones de alma para cargar tu objeto activo#No puede tener Corazones de Alma,Bethany,Bethany,{{SoulHeart}} Dùng Trái tim hồn để nạp vật phẩm hoạt động#Không thể dùng Trái tim hồn làm máu,Bethany,1
+405,Jacob and Esau,Jacob and Esau,Character,야곱과 에사우,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,Jacob and Esau,1
+406,The Planetarium,Planetarium,Other,행성방 등장,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,Planetarium,1
+407,A Secret Exit,Downpour,Map,,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,Downpour,1
+408,Forgotten Lullaby,Forgotten Lullaby,Trinket,잊혀진 자장가,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,Forgotten Lullaby,1
+409,Fruity Plum,Fruity Plum,Item,탱탱한 플럼,Fruity Plum,Švestička,Fruchtiger Plum,Fruity Plum,Fruity Plum,P'tite Prunelle,Plum Fruttato,フルーティ プラム,Fruity Plum,Owocowy Plum,Fruity Plum,Fruity Plum,Prune Fructate,Фруктовый малыш,Ciruela afrutada,Meyvalı Erik,Мала Слива,Fruity Plum,甜甜糖梅宝,1
+410,Plum Flute,Plum Flute,Item,플럼 피리,Plum Flute,Švestkova Flétna,Plum-Flöte,Plum Flute,Plum Flute,Flute Prunelle,Flauto Plum,プラムのふえ,Plum Flute,Flet Plum,Plum Flute,Plum Flute,Fluierul lui Plum,Сливовая флейта,Flauta ciruela,Erik Flütü,Сливова флейта,Plum Flute,糖梅溜溜笛,1
+411,Rotten Heart,Rotten Heart,Pickup,썩은 하트,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,Rotten Heart,1
+412,Dross,Dross,Map,,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,Dross,1
+413,Ashpit,Ashpit,Map,,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,Ashpit,1
+414,Gehenna,Gehenna,Map,,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,Gehenna,1
+415,Red Key,Red Key,Item,붉은 열쇠,Red Key,Červený Klíč,Roter Schlüssel,Red Key,Red Key,Clé Rouge,Chiave Rossa,レッド キー,Red Key,Czerwony Klucz,Red Key,Red Key,Cheie Roșie,Красный ключ,Llave roja,Kırmızı Anahtar,Червоний ключ,Red Key,红钥匙,1
+416,Wisp Baby,Wisp Baby,Other,랜덤 패밀리어,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,Wisp Baby,1
+417,Book of Virtues,Book of Virtues,Item,미덕의 책,Book of Virtues,Kniha Ctností,Buch der Tugenden,Book of Virtues,Book of Virtues,Livre des Vertus,Libro delle Virtù,美徳の書,Book of Virtues,Księga płomyków,Book of Virtues,Book of Virtues,Cartea Virtuților,Книга добродетелей,El libro de las virtudes,Erdem Kitabı,Книга Чеснот,Book of Virtues,美德之书,1
+418,Urn of Souls,Urn of Souls,Item,영혼의 항아리,Urn of Souls,Urna duší,Urne Der Seelen,Urn of Souls,Urn of Souls,Urne des Âmes,Urna di Anime,魂の壺,Urn of Souls,Urna dusz,Urn of Souls,Urn of Souls,Urna Sufletelor,Урна душ,Urna de almas,Ruh Vazosu,Урна душ,Urn of Souls,灵魂之瓮,1
+419,Blessed Penny,Blessed Penny,Trinket,축복받은 동전,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,Blessed Penny,1
+420,Alabaster Box,Alabaster Box,Item,석고 옥합,Alabaster Box,Alabastrová krabička,Alabaster-Box,Alabaster Box,Alabaster Box,Boîte d'Albâtre,Scatola di Alabastro,アラバスタ ボックス,Alabaster Box,Alabasterowe pudełko,Alabaster Box,Alabaster Box,Cutie de Alabastru,Алебастровая шкатулка,Caja de alabastro,Mermer Sandık,Алебастрова скринька,Alabaster Box,白玉香膏盒,1
+421,Beth's Faith,Beth's Faith,Trinket,베다니의 축복,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,Beth's Faith,1
+422,Soul Locket,Soul Locket,Item,영혼 로켓,Soul Locket,Duševní Medailónek,Seelenamulett,Soul Locket,Soul Locket,Pendentif des Âmes,Ciondolo Celeste,ソウル ロケット,Soul Locket,Medalik Duszy,Soul Locket,Soul Locket,Medalion Suflet,Медальон души,Relicario del Alma,Ruh Kolyesi,Медальйон душі,Soul Locket,灵魂吊坠,1
+423,Divine Intervention,Divine Intervention,Item,신의 개입,Divine Intervention,Boží Zásah,Göttliche Intervention,Divine Intervention,Divine Intervention,Intervention Divine,Intervento Divino,神々の介入,Divine Intervention,Boska Ingerencja,Divine Intervention,Divine Intervention,Intervenție Divină,Божественное вмешательство,Intervención divina,İlahi Müdahale,Божественне втручання,Divine Intervention,神圣干预,1
+424,Vade Retro,Vade Retro,Item,사탄아 물렀거라,Vade Retro,Ustup,Vade Retro,Vade Retro,Vade Retro,Vade Retro,Vade Retro,ヴァデ レトロ,Vade Retro,Vade Retro,Vade Retro,Vade Retro,Vade Retro,Возвратися воспять,Vade Retro,Vade Retro,Повернись!,Vade Retro,驱魔护符,1
+425,Star of Bethlehem,Star of Bethlehem,Item,베들레헴의 별,Star of Bethlehem,Betlémská Hvězda,Stern von Bethlehem,Star of Bethlehem,Star of Bethlehem,Star of Bethlehem,Stella di Betlemme,ベツレヘムの星,Star of Bethlehem,Gwiazda Betlejemska,Star of Bethlehem,Star of Bethlehem,Steaua din Betleem,Вифлеемская звезда,Estrella de Belén,Bethlehem Yıldızı,Вифлеємська зірка,Star of Bethlehem,伯列恒之星,1
+426,Hope Baby,Hope Baby,Other,랜덤 패밀리어,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,Hope Baby,1
+427,Glowing Baby,Glowing Baby,Other,랜덤 패밀리어,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,Glowing Baby,1
+428,Double Baby,Double Baby,Other,랜덤 패밀리어,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,Double Baby,1
+429,The Stairway,The Stairway,Item,천국의 계단,The Stairway,Schodiště,Die Treppe,The Stairway,The Stairway,Échelle Vers les Cieux,La Scalinata,天国への階段,The Stairway,Przejście,The Stairway,The Stairway,Scara,Лестница,La escalerilla,Merdiven,Сходи,The Stairway,天堂阶梯,1
+430,Red Stew,Red Stew,Item,붉은 스튜,Red Stew,Červený Guláš,Roter Eintopf,Red Stew,Red Stew,Potage de Lentilles,Stufato Rosso,レッド シチュー,Red Stew,Czerwony gulasz,Red Stew,Red Stew,Tocană Roșie,Красная похлёбка,Guisado Rojo,Kırmızı Çorba,Червоне рагу,Red Stew,红豆汤,1
+431,Birthright,Birthright,Item,생득권,Birthright,Prvorozenství,Geburtsrecht,Birthright,Birthright,Droit d'Aînesse,Primogenitura,バースライト,Birthright,Prawo Urodzenia,Birthright,Birthright,Drept Ereditar,Право первородства,Primogenitura,Kan Hakkı,Право первородства,Birthright,长子名分,1
+432,Damocles,Damocles,Item,다모클레스,Damocles,Damoklův Meč,Damokles,Damocles,Damocles,Damoclès,Damocle,ダモクレス,Damocles,Damocles,Damocles,Damocles,Damocles,Дамокл,Damocles,Demokles,Дамокл,Damocles,达摩克里斯之剑,1
+433,Rock Bottom,Rock Bottom,Item,밑바닥,Rock Bottom,Samé Dno,Grundgestein,Rock Bottom,Rock Bottom,Au Fond du Trou,Caduto in Basso,どん底,Rock Bottom,Kamień z dna,Rock Bottom,Rock Bottom,La Pământ,Каменное дно,Fondo rocoso,Dibin Dibi,Кам'яне дно,Rock Bottom,谷底石,1
+434,Inner Child,Inner Child,Item,내면의 아이,Inner Child,Vnitřní Dítě,Inneres Kind,Inner Child,Inner Child,Enfant Intérieur,Fanciullo Interiore,インナー チャイルド,Inner Child,Wewnętrzne dziecko,Inner Child,Inner Child,Copilul Interior,Внутренний ребёнок,Niño Interior,İçindeki Çocuk,Внутрішня дитина,Inner Child,内在孩童,1
+435,Vanishing Twin,Vanishing Twin,Item,사라진 쌍둥이,Vanishing Twin,Mizející Dvojče,Verschwindender Zwilling,Vanishing Twin,Vanishing Twin,Jumeau Évanescent,Gemello Evanescente,バニッシング ツイン,Vanishing Twin,Zanikający bliźniak,Vanishing Twin,Vanishing Twin,Geamănul Dispărut,Исчезающий близнец,Gemelo Desvaneciente,Kaybolan İkiz,Зникаючий близнюк,Vanishing Twin,消失的胞胎,1
+436,Genesis,Genesis,Item,창세기,Genesis,Genesis,Genesis,Genesis,Genesis,Genèse,Genesi,ジェネシス,Genesis,Geneza,Genesis,Genesis,Geneză,Генезис,Génesis,Yaratılış,Генезис,Genesis,创世记,1
+437,Suplex!,Suplex!,Item,수플렉스!,Suplex!,Suplex!,Suplex!,Suplex!,Suplex!,Suplex !,Suplex!,スープレックス！,Suplex!,Suplex!,Suplex!,Suplex!,Suplex!,Суплекс!,¡Suplex!,Suplex!,Суплекс!,Suplex!,背摔！,1
+438,Solomon's Baby,Solomon's Baby,Other,랜덤 패밀리어,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,Solomon's Baby,1
+439,Illusion Baby,Illusion Baby,Other,랜덤 패밀리어,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,Illusion Baby,1
+440,Meat Cleaver,Meat Cleaver,Item,고기 도축칼,Meat Cleaver,Sekáček Na Maso,Fleischermesser,Meat Cleaver,Meat Cleaver,Couteau de Boucher,Mannaia,ブッチャーナイフ,Meat Cleaver,Tasak do Mięsa,Meat Cleaver,Meat Cleaver,Satâr de Carne,Мясной тесак,Cuchillo de carnicero,Et Satırı,Тесак м'ясника,Meat Cleaver,切肉刀,1
+441,Options?,Options?,Item,선택권?,Options?,Možnosti?,Optionen?,Options?,Options?,Plus d'Options ?,Alternative?,オプション？,Options?,Opcje?,Options?,Options?,Opțiuni?,Выбор?,¿Opciones?,Seçenekler?,Варіанти?,Options?,选择？,1
+442,Yuck Heart,Yuck Heart,Item,역겨운 하트,Yuck Heart,Fuj Srdce,Ekelherz,Yuck Heart,Yuck Heart,Cœur Moisi,Cuore Schifoso,ヤック ハート,Yuck Heart,Zgniłe serce,Yuck Heart,Yuck Heart,Inimă Dezgustătoare,Фу-сердце,Corazón asqueroso,İğrenç Kalp,Гидотне серце,Yuck Heart,难吃的心,1
+443,Candy Heart,Candy Heart,Item,캔디 하트,Candy Heart,Cukrové Srdce,Bonbonherz,Candy Heart,Candy Heart,Cœur Confit,Dolce Cuore,キャンディハート,Candy Heart,Cukrowe serduszko,Candy Heart,Candy Heart,Inimă Bomboană,Конфетное сердце,Corazón de Caramelo,Şeker Kalp,Цукеркове серце,Candy Heart,糖心,1
+444,Guppy's Eye,Guppy's Eye,Item,구피의 눈,Guppy's Eye,Guppyho Oko,Guppys Auge,Guppy's Eye,Guppy's Eye,Œil de Guppy,Occhio di Guppy,ガッピーの目,Guppy's Eye,Oko Guppyego,Guppy's Eye,Guppy's Eye,Ochiul lui Guppy,Глаз Гаппи,El ojo de Guppy,Şerbet'in Gözü,Око Гаппі,Guppy's Eye,嗝屁猫的眼睛,1
+445,A Pound of Flesh,A Pound of Flesh,Item,살점 한 덩이,A Pound of Flesh,Kilo masa,Ein Pfund Fleisch,A Pound of Flesh,A Pound of Flesh,Une Livre de Chair,Un Etto di Carne,１ポンドの肉,A Pound of Flesh,Porcja mięsa,A Pound of Flesh,A Pound of Flesh,Un Kg de Carne,Фунт плоти,Una Libra de Carne,Kilo ile Et,Фунт м'яса,A Pound of Flesh,一磅肉,1
+446,Akeldama,Akeldama,Item,아겔다마,Akeldama,Akeldama,Blutacker,Akeldama,Akeldama,Haqeldemah,Akeldama,アケルダマ,Akeldama,Akeldama,Akeldama,Akeldama,Acheldama,Акелдама,Aceldama,Akeldama,Акелдама,Akeldama,血田,1
+447,Redemption,Redemption,Item,회개,Redemption,Vykoupení,Erlösung,Redemption,Redemption,Rédemption,Redenzione,リデンプション,Redemption,Odkupienie,Redemption,Redemption,Mântuire,Искупление,Redención,Kefaret,Спокута,Redemption,赎罪,1
+448,Eternal D6,Eternal D6,Item,이터널 주사위,Eternal D6,Věčná D6,Ewiges D6,Eternal D6,Eternal D6,D6 Éternel,D6 Eterno,エターナルＤ６,Eternal D6,Wieczne D6,Eternal D6,Eternal D6,D6 Etern,Вечный D6,D6 Eterno,Ebedi D6,Вічний D6,Eternal D6,永恒六面骰,1
+449,Montezuma's Revenge,Montezuma's Revenge,Item,몬테주마의 복수,Montezuma's Revenge,Montezumova Pomsta,Montezumas Rache,Montezuma's Revenge,Montezuma's Revenge,Tourista,Vendetta di Montezuma,モンテズマズ リベンジ,Montezuma's Revenge,Zemsta Montezumy,Montezuma's Revenge,Montezuma's Revenge,Răzbunarea lui Montezuma,Месть Монтесумы,Venganza de Montezuma,Montezuma'nın İntikamı,Помста Монтезуми,Montezuma's Revenge,水土不服症,1
+450,Bird Cage,Bird Cage,Item,새장,Bird Cage,Ptačí Klec,Vogelkäfig,Bird Cage,Bird Cage,Gros Piaf,Gabbia per Uccelli,バードケージ,Bird Cage,Klatka dla ptaków,Bird Cage,Bird Cage,Colivie pentru Păsări,Птичья клетка,Pecho de Ave,Kuş Kafesi,Пташина клітка,Bird Cage,鸟肥笼,1
+451,Cracked Orb,Cracked Orb,Item,깨진 오브,Cracked Orb,Popraskaný Orb,Rissige Kugel,Cracked Orb,Cracked Orb,Orbe Fêlé,Sfera Incrinata,ひび割れたオーブ,Cracked Orb,Popękana kula,Cracked Orb,Cracked Orb,Sferă Spartă,Треснувший шар,Orbe Roto,Kırık Küre ,Розбита куля,Cracked Orb,碎裂的宝珠,1
+452,Bloody Gust,Bloody Gust,Item,피의 돌풍,Bloody Gust,Krvavý Závan,Blutiger Windstoß,Bloody Gust,Bloody Gust,Souffle de Sang,Soffio Furente,血まみれの突風,Bloody Gust,Krwawy zryw,Bloody Gust,Bloody Gust,Rafală Sângeroasă,Кровавый порыв,Ráfaga de Sangre,Kanlı Rüzgar,Кривавий порив,Bloody Gust,嗜血腥风,1
+453,Empty Heart,Empty Heart,Item,비어있는 심장,Empty Heart,Prázdné Srdce,Leeres Herz,Empty Heart,Empty Heart,Cœur Vide,Cuore Vuoto,エンプティ ハート,Empty Heart,Puste serce,Empty Heart,Empty Heart,Inimă Goală,Пустое сердце,Corazón Vacío,Boş Kalp,Порожнє серце,Empty Heart,空虚之心,1
+454,Devil's Crown,Devil's Crown,Trinket,악마의 왕관,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,Devil's Crown,1
+455,Lil Abaddon,Lil Abaddon,Item,꼬마 아바돈,Lil Abaddon,Malej Abaddón,Lil Abaddon,Lil Abaddon,Lil Abaddon,P'tit Abaddon,Mini Abbadon,リトル アバドン,Lil Abaddon,Lil Abaddon,Lil Abaddon,Lil Abaddon,Micul Abaddon,Малютка Абаддон,Mini Abadón,Minik Abaddon,Крихітний Абаддон,Lil Abaddon,亚巴顿宝宝,1
+456,Tinytoma,Tinytoma,Item,타이니토마,Tinytoma,Malý Teratom,Tinytoma,Tinytoma,Tinytoma,P'tit Tératome,Minitoma,タイニートーマ,Tinytoma,Minitoma,Tinytoma,Tinytoma,Minitoma,Минитома,Minitoma,Tinytoma,Мінітома,Tinytoma,小畸胎瘤,1
+457,Astral Projection,Astral Projection,Item,유체이탈,Astral Projection,Astrální Projekce,Astrale Projektion,Astral Projection,Astral Projection,Projection Astrale,Proiezione Astrale,アストラル プロジェクション,Astral Projection,Astralna Projekcja,Astral Projection,Astral Projection,Proiecție Astrală,Астральная проекция,Proyección Astral,Astral Projeksiyon,Астральна проекція,Astral Projection,灵魂出窍,1
+458,'M,'M,Trinket,,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,'M,1
+459,Everything Jar,Everything Jar,Item,모든 게 담긴 병,Everything Jar,Sklenice Všeho Možného,Allesglas,Everything Jar,Everything Jar,Bocal de N'Importe Quoi,Giara Universale,エブリシング ジャー,Everything Jar,Wszystkosłój,Everything Jar,Everything Jar,Borcan cu de Toate,Банка для всего,Jarra Para Todo,Her Şey Kavanozu,Банка всього,Everything Jar,百宝罐,1
+460,Lost Soul,Lost Soul,Item,잃어버린 영혼,Lost Soul,Ztracená Duše,Verlorene Seele,Lost Soul,Lost Soul,Âme Égarée,Anima Smarrita,ロスト ソウル,Lost Soul,Zagubiona dusza,Lost Soul,Lost Soul,Suflet Pierdut,Потерянная душа,Alma Perdida,Kayıp Ruh,Загублена душа,Lost Soul,迷失游魂,1
+461,Hungry Soul,Hungry Soul,Item,굶주린 영혼,Hungry Soul,Hladová Duše,Hungrige Seele,Hungry Soul,Hungry Soul,Âme Affamée,Anima Affamata,ハングリー ソウル,Hungry Soul,Głodna dusza,Hungry Soul,Hungry Soul,Suflet Înfometat,Голодная душа,Alma Hambrienta,Aç Ruh,Голодна душа,Hungry Soul,饥饿幽魂,1
+462,Blood Puppy,Blood Puppy,Item,핏덩이 강아지,Blood Puppy,Krvavé Štěně,Blutwelpe,Blood Puppy,Blood Puppy,Chiot de Sang,Cucciolo Sanguinario,ブラッドパピー,Blood Puppy,Krwawy zwierzak,Blood Puppy,Blood Puppy,Cățeluș Însângerat,Кровавый щенок,Cachorro sangriento,Kan Köpeği,Кривавий цуцик,Blood Puppy,嗜血小宠,1
+463,C Section,C Section,Item,제왕절개,C Section,Císařský Řez,Kaiserschnitt,C Section,C Section,Césarienne,Taglio Cesareo,帝王切開,C Section,Sekcja C,C Section,C Section,Cezariană,Кесарево,Cesárea,Sezaryen,Кесарів розтин,C Section,剖腹产,1
+464,Keeper's Sack,Keeper's Sack,Item,키퍼의 자루,Keeper's Sack,Keeperův Pytel,Sack Des Keepers,Keeper's Sack,Keeper's Sack,Bourse du Gardien,Sacca del Mercante,キーパーズ サック,Keeper's Sack,Sakiewka Keepera,Keeper's Sack,Keeper's Sack,Sacul lui Keeper,Мешок Хранителя,Bolsa de Keeper,Keeper'ın Kesesi,Мішок Хранителя,Keeper's Sack,店主的胯袋,1
+465,Keeper's Box,Keeper's Box,Item,키퍼의 상자,Keeper's Box,Keeperova Bedna,Keepers Kiste,Keeper's Box,Keeper's Box,Boîte du Gardien,Scatola del Mercante,キーパーズ ボックス,Keeper's Box,Pudełko Keepera,Keeper's Box,Keeper's Box,Cutia lui Keeper,Коробок Хранителя,Caja de Keeper,Keeper'ın Sandığı,Коробка Хранителя,Keeper's Box,店主的盒子,1
+466,Lil Portal,Lil Portal,Item,꼬마 포탈,Lil Portal,Malý Portál,Lil Portal,Lil Portal,Lil Portal,P'tit Vortex,Mini Portale,リトル ポータル,Lil Portal,Lil Portal,Lil Portal,Lil Portal,Micul Portal,Малютка портал,Portal Pequeño,Minik Portal,Крихітний портал,Lil Portal,黑洞宝宝,1
+467,Worm Friend,Worm Friend,Item,지렁이 친구,Worm Friend,Červí Kámoš,Wurmfreund,Worm Friend,Worm Friend,Ver de Nerf,Amico Verme,ワーム フレンド,Worm Friend,Przyjaciel robak,Worm Friend,Worm Friend,Prieten Vierme,Червячок-друг,Amigo Gusano,Solucan Arkadaş,Друг Черв'ячок,Worm Friend,触手朋友,1
+468,Bone Spurs,Bone Spurs,Item,골국,Bone Spurs,Kostní Ostruha,Knochensporn,Bone Spurs,Bone Spurs,Épines Osseuses,Speroni Ossei,ボーン スパーズ,Bone Spurs,Ostre Kostki,Bone Spurs,Bone Spurs,Pinten Osos,Костяные выступы,Espuelas de Hueso,Kemik Çıkıntıları,Кісткові шпори,Bone Spurs,骨刺,1
+469,Spirit Shackles,Spirit Shackles,Item,영혼의 족쇄,Spirit Shackles,Duševní Pouta,Geistschellen,Spirit Shackles,Spirit Shackles,Chaînes de l'Esprit,Catene Spirituali,スピリット シャックル,Spirit Shackles,Duchowe kajdany,Spirit Shackles,Spirit Shackles,Lanțuri Spirit,Духовные цепи,Grilletes Espirituales,Ruhun Prangaları,Духовні кайдани,Spirit Shackles,灵魂枷锁,1
+470,Revelation,Revelation,Item,계시,Revelation,Zjevení,Offenbarung,Revelation,Revelation,Révélation,Rivelazione,リベレイション,Revelation,Objawienie,Revelation,Revelation,Revelație,Откровение,Revelación,Devrim,Одкровення,Revelation,终末天启,1
+471,Jar of Wisps,Jar of Wisps,Item,도깨비불 든 병,Jar of Wisps,Nádoba s Bludičkami,Glas mit Wisps,Jar of Wisps,Jar of Wisps,Bocal de Feux Follets,Giara di Fiammelle,ウィスプの壺,Jar of Wisps,Słoik ogników,Jar of Wisps,Jar of Wisps,Borcan cu Musculițe,Банка огоньков,Tarro de Avispas,Wisp Kavanozu,Банка вогників,Jar of Wisps,魂火罐,1
+472,Magic Skin,Magic Skin,Item,마법의 피부,Magic Skin,Kouzelná Kůže,Zauberhaut,Magic Skin,Magic Skin,Peau de Chagrin,Pelle Magica,マジックスキン,Magic Skin,magiczna skóra,Magic Skin,Magic Skin,Piele Magică,Магическая кожа,Piel mágica,Sihirli Ten,Чарівна шкіра,Magic Skin,玄奇驴皮,1
+473,Friend Finder,Friend Finder,Item,친구 찾기,Friend Finder,Hledač Přátel,Freundesfinder,Friend Finder,Friend Finder,Amis Imaginaires,Cerca Amici,フレンド ファインダー,Friend Finder,Znajdywacz przyjaciół,Friend Finder,Friend Finder,Găsitor de Prieteni,Поиск друзей,Buscador de Amigos,Arkadaş Bulucu,Пошук друзів,Friend Finder,寻友护符,1
+474,The Broken,Tainted Isaac,Character,더럽혀진 아이작,Tainted Isaac,Tainted Isaac,Tainted Isaac,Tainted Isaac,Tainted Isaac,Isaac Impur,Tainted Isaac,アイテムが二択状態で 生成される#パッシブアイテムは 8個までしか持てず、 9個目のアイテムは {{ButtonRT}}で選んで入れ替える,Tainted Isaac,Splamiony Izaak,Tainted Isaac,Tainted Isaac,Item pedestals cycle between 2 options#You can only carry 8 passive items#Change which item will be dropped for a 9th item with {{ButtonRT}},Tainted Isaac,Isaac Corrupto,Tainted Isaac,Tainted Isaac,Bệ vật phẩm chuyển đổi giữa 2 lựa chọn#Chỉ có thể mang 8 vật phẩm thụ động#Thay đổi vật phẩm sẽ bị làm rơi cho vật phẩm thứ 9 bằng {{ButtonRT}},Tainted Isaac,1
+475,The Dauntless,Tainted Magdalene,Character,더럽혀진 막달레나,Tainted Magdalene,Tainted Magdalene,Tainted Magdalene,Tainted Magdalene,Tainted Magdalene,Marie Impure,Tainted Magdalene,赤ハートが2個以上ある時、 体力が徐々に減少する#死んだ敵は、2秒で消える 半赤ハートを確率で落とす#敵に接触時、自動的に 近接攻撃が発動し、 6倍のダメージを与える#この効果で倒された敵は、 半赤ハートを確定で落とす#アイテムやカードなどの 体力回復効果2倍#減少部分の赤ハートは、 悪魔部屋の出現確率に 影響しない,Tainted Magdalene,Splamiona Magdalena,Tainted Magdalene,Tainted Magdalene,"Health above 2 Red Hearts will slowly drain#On contact, do a melee swing for 6x damage#{{HalfRedHeart}} Chance for enemies to drop Half Red Hearts that disappear in 2 seconds#Drop is guaranteed on melee kill#{{Collectible45}} Heal twice as much from non-pickup sources#{{AngelDevilChance}} Damage taken to draining hearts doesn't affect Devil Deal chance",Tainted Magdalene,Magdalena Corrupta,Tainted Magdalene,Tainted Magdalene,"Máu trên 2 Trái tim đỏ sẽ từ từ cạn#Khi tiếp xúc, thực hiện cú đánh cận chiến gây sát thương gấp 6#{{HalfRedHeart}} Cơ hội để kẻ thù làm rơi Nửa Trái tim đỏ biến mất sau 2 giây#Đảm bảo rơi khi giết bằng cận chiến#{{Collectible45}} Hồi máu gấp đôi từ nguồn không phải vật phẩm nhặt#{{AngelDevilChance}} Sát thương lên trái tim cạn không ảnh hưởng đến cơ hội Giao kèo Quỷ",Tainted Magdalene,1
+476,The Hoarder,Tainted Cain,Character,더럽혀진 카인,Tainted Cain,Tainted Cain,Tainted Cain,Tainted Cain,Tainted Cain,Caïn Impur,Tainted Cain,触れたアイテムが 各種ピックアップに 変換される,Tainted Cain,Splamiony Kain,Tainted Cain,Tainted Cain,Touching an item pedestal turns it into a variety of pickups,Tainted Cain,Caín Corrupto,Tainted Cain,Tainted Cain,Chạm vào bệ vật phẩm biến nó thành nhiều loại vật phẩm nhặt khác nhau,Tainted Cain,1
+477,The Deceiver,Tainted Judas,Character,더럽혀진 유다,Tainted Judas,Tainted Judas,Tainted Judas,Tainted Judas,Tainted Judas,Judas Impur,Tainted Judas,赤ハートを持てない#体力が増える効果は、 代わりに黒ハート+1,Tainted Judas,Splamiony Judasz,Tainted Judas,Tainted Judas,Can't have Red Hearts#{{BlackHeart}} Health ups grant Black Hearts,Tainted Judas,Judas Corrupto,Tainted Judas,Tainted Judas,Không thể có Trái tim đỏ#{{BlackHeart}} Tăng máu tặng Trái tim đen,Tainted Judas,1
+478,The Soiled,Tainted ???,Character,더럽혀진 ???,Tainted ???,Tainted ???,Tainted ???,Tainted ???,Tainted ???,??? Impur,Tainted ???,爆弾とうんちが置き換わる#{{Crafting29}} 敵にダメージを与えると うんちピックアップが スポーンする#{{Collectible715}} うんちを1個ホールドし、 あとで使うことができる,Tainted ???,Splamiony ???,Tainted ???,Tainted ???,Bombs are replaced with Poop Spells#{{Crafting29}} Doing damage spawns poop pickups#{{Collectible715}} You can store the next spell for later by using Hold,Tainted ???,??? Corrupto,Tainted ???,Tainted ???,Bom được thay bằng Phép Phân#{{Crafting29}} Gây sát thương tạo vật phẩm nhặt phân#{{Collectible715}} Bạn có thể lưu phép tiếp theo để dùng sau bằng Hold,Tainted ???,1
+479,The Curdled,Tainted Eve,Character,더럽혀진 이브,Tainted Eve,Tainted Eve,Tainted Eve,Tainted Eve,Tainted Eve,Ève Impure,Tainted Eve,攻撃ボタンを押し続けると 体力が消費され、血餅の 使い魔がスポーンする#サンプトリウムを使うと 血餅は体力になって戻る#消費されたハートの種類に 応じて血餅の特性が変化する#{{ButtonRT}}で血餅を固定できる#以下の条件時、近接攻撃型の キャラに変化し、移動速度と 攻撃力が増加する： ・血餅が無く、残り体力が 　半ハートになった時 ・残り体力がハート1個の 　状態で血餅を出した時,Tainted Eve,Splamiona Ewa,Tainted Eve,Tainted Eve,"Holding Fire converts your hearts into Clot familiars#Different Heart types spawn Clots with more health and tear effects#Clots lose health over time#Clots stay in place while holding {{ButtonRT}}#At half a heart left with no Clots, you gain a Mom's Knife-like attack until you heal and leave the room",Tainted Eve,Eva Corrupta,Tainted Eve,Tainted Eve,"Giữ nút Bắn biến trái tim của bạn thành bạn đồng hành Cục máu#Các loại Trái tim khác nhau tạo Cục máu với máu và hiệu ứng nước mắt nhiều hơn#Cục máu mất máu theo thời gian#Cục máu đứng yên khi giữ {{ButtonRT}}#Khi còn nửa trái tim không có Cục máu, bạn nhận đòn tấn công kiểu Mom's Knife cho đến khi hồi máu và rời phòng",Tainted Eve,1
+480,The Savage,Tainted Samson,Character,더럽혀진 삼손,Tainted Samson,Tainted Samson,Tainted Samson,Tainted Samson,Tainted Samson,Samson Impur,Tainted Samson,与えた／受けたダメージが 一定量に達すると、5秒間 バーサーカー状態になり、 以下の効果を得る：#↑ 移動速度 +0.4#↑ 連射速度#↑ 攻撃力　 +3#涙を骨による近接攻撃に 置き換える#敵を倒すと持続+1秒＆ 短時間の無敵状態,Tainted Samson,Splamiony Samson,Tainted Samson,Tainted Samson,"Dealing or taking damage builds up Berserk mode#{{Timer}} When you go berserk, receive for 5 seconds:#↑ {{Speed}} +0.4 Speed#↓ {{Tears}} x0.5 Fire rate multiplier#↑ {{Tears}} +2 Fire rate#↑ {{Damage}} +3 Damage#Restricts attacks to a melee that reflects shots#{{Timer}} Each kill increases the duration by 1 second and grants brief invincibility",Tainted Samson,Sansón Corrupto,Tainted Samson,Tainted Samson,"Gây hoặc nhận sát thương tích lũy chế độ Berserk#{{Timer}} Khi bạn cuồng nộ, nhận trong 5 giây:#↑ {{Speed}} +0.4 Tốc độ#↓ {{Tears}} x0.5 Hệ số tốc độ bắn#↑ {{Tears}} +2 Tốc độ bắn#↑ {{Damage}} +3 Sát thương#Hạn chế tấn công thành cận chiến phản đạn#{{Timer}} Mỗi lần giết tăng thời gian thêm 1 giây và tặng bất tử ngắn",Tainted Samson,1
+481,The Benighted,Tainted Azazel,Character,더럽혀진 아자젤,Tainted Azazel,Tainted Azazel,Tainted Azazel,Tainted Azazel,Tainted Azazel,Azazel Impur,Tainted Azazel,攻撃チャージ開始時に 吐血し、呪いの効果と 1.5倍のダメージを与える#吐血が敵に当たると、 チャージ時間が半減する#{{BrimstoneCurse}} 呪われた敵はビームから 追加のダメージを受け、 死亡時に爆発し、周囲の 敵に呪いを拡散する,Tainted Azazel,Splamiony Azazel,Tainted Azazel,Tainted Azazel,"When you start charging, you sneeze blood#Hitting an enemy with the sneeze halves your charge time#The sneeze deals 1.5x Azazel's damage#{{BrimstoneCurse}} Affected enemies take extra damage from Brimstone beams#On death, cursed enemies explode and pass on the curse to nearby enemies",Tainted Azazel,Azazel Corrupto,Tainted Azazel,Tainted Azazel,"Khi bắt đầu nạp, bạn hắt hơi máu#Trúng kẻ thù bằng hắt hơi giảm nửa thời gian nạp#Hắt hơi gây sát thương gấp 1.5 lần của Azazel#{{BrimstoneCurse}} Kẻ thù bị ảnh hưởng nhận thêm sát thương từ tia Brimstone#Khi chết, kẻ thù bị nguyền nổ và truyền lời nguyền cho kẻ thù gần đó",Tainted Azazel,1
+482,The Enigma,Tainted Lazarus,Character,더럽혀진 나사로,Tainted Lazarus,Tainted Lazarus,Tainted Lazarus,Tainted Lazarus,Tainted Lazarus,Lazare Impur,Tainted Lazarus,裏と表の二形態があり、 各々個別のアイテムと ステータスを持つ#部屋をクリアした時と、 フリップを使用した時、 裏表が入れ替わる,Tainted Lazarus,Splamiony Łazarz,Tainted Lazarus,Tainted Lazarus,"Lazarus has two states, each with their own items and health#Clearing a room/wave or using Flip switches to the other state",Tainted Lazarus,Lázaro Corrupto,Tainted Lazarus,Tainted Lazarus,"Lazarus có hai trạng thái, mỗi trạng thái có vật phẩm và máu riêng#Dọn phòng/sóng hoặc dùng Flip để chuyển trạng thái",Tainted Lazarus,1
+483,The Capricious,Tainted Eden,Character,더럽혀진 에덴,Tainted Eden,Tainted Eden,Tainted Eden,Tainted Eden,Tainted Eden,Éden Impur,Tainted Eden,ダメージを受けるたびに ステータス、アイテム、 トリンケット、所持品が リロールされる#アイテムは、同じプール から選択・リロールされる#自傷ダメージはリロール無し,Tainted Eden,Splamiony Eden,Tainted Eden,Tainted Eden,"When you take damage, reroll your stats, items, trinket, and consumables#Items reroll into an item from the same item pool#Self-damage doesn't reroll",Tainted Eden,Edén Corrupto,Tainted Eden,Tainted Eden,"Khi nhận sát thương, đổi lại chỉ số, vật phẩm, bùa và vật phẩm tiêu thụ của bạn#Vật phẩm đổi lại thành vật phẩm từ cùng nhóm vật phẩm#Tự gây sát thương không đổi lại",Tainted Eden,1
+484,The Baleful,Tainted Lost,Character,더럽혀진 로스트,Tainted Lost,Tainted Lost,Tainted Lost,Tainted Lost,Tainted Lost,L'Égaré Impur,Tainted Lost,{{Card51}} スポーンするカードが 10%の確率で聖なるカードに 置き換わる#品質{{Quality2}}以下のアイテムは、 20%の確率でリロールされる#攻撃型のアイテムのみ スポーンする,Tainted Lost,Splamiony Zaginiony,Tainted Lost,Tainted Lost,"{{Card51}} Cards that spawn have a 10% chance to be Holy Card#Quality {{Quality2}} or less items have a 20% chance to be rerolled#Only ""offensive"" items can spawn",Tainted Lost,El Perdido Corrupto,Tainted Lost,Tainted Lost,"{{Card51}} Lá bài xuất hiện có 10% cơ hội là Holy Card#Vật phẩm chất lượng {{Quality2}} hoặc thấp hơn có 20% cơ hội được đổi lại#Chỉ vật phẩm ""tấn công"" mới có thể xuất hiện",Tainted Lost,1
+485,The Harlot,Tainted Lilith,Character,더럽혀진 릴리스,Tainted Lilith,Gellovo slzné poškození je dvojnásobné,Tainted Lilith,Tainted Lilith,Tainted Lilith,Double les dégâts des larmes de Gello,"Danni delle lacrime di ""Gellò"" raddoppiati",ゲローの涙ダメージ2倍,Tainted Lilith,Splamiona Lilit ,Tainted Lilith,Tainted Lilith,Gello's tear damage is doubled,Tainted Lilith,Duplica el daño de las lágrimas de Gello,Tainted Lilith,Tainted Lilith,Sát thương nước mắt của Gello gấp đôi,格罗的泪弹伤害翻倍,1
+486,The Miser,Tainted Keeper,Character,더럽혀진 키퍼,Tainted Keeper,Tainted Keeper,Tainted Keeper,Tainted Keeper,Tainted Keeper,Le Gardien Impur,Tainted Keeper,最大体力2#敵が2秒で消える コインを落とす#アイテム取得時、 15コイン支払う#お店の品ぞろえが 強化され、入店時 鍵を消費しない,Tainted Keeper,Splamiony Dozorca,Tainted Keeper,Tainted Keeper,Maximum of 2 Coin Hearts#Enemies drop coins that disappear in 2 seconds#Most item pedestals cost 15 coins#Devil deals and Angel items cost 15 or 30 coins#Shops don't require a key and have increased stock,Tainted Keeper,Keeper Corrupto,Tainted Keeper,Tainted Keeper,Tối đa 2 Trái tim xu#Kẻ thù làm rơi đồng xu biến mất sau 2 giây#Hầu hết bệ vật phẩm tốn 15 đồng xu#Giao kèo quỷ và vật phẩm Thiên thần tốn 15 hoặc 30 đồng xu#Cửa hàng không cần chìa khóa và có hàng tồn kho tăng,Tainted Keeper,1
+487,The Empty,Tainted Apollyon,Character,더럽혀진 아폴리온,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Apollyon Impur,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Splamiony Apollyon,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Apolión Corrupto,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,Tainted Apollyon,1
+488,The Fettered,Tainted Forgotten,Character,더럽혀진 포가튼,Tainted Forgotten,Tainted Forgotten,Tainted Forgotten,Tainted Forgotten,Tainted Forgotten,Le Délaissé Impur,Tainted Forgotten,移動できない無敵の フォーガットンを、 攻撃できないソウルが 運び投げて戦う#爆弾はフォーガットンの 位置に置かれる#赤ハートを持てない#体力が増える効果は、 代わりに青ハート+1,Tainted Forgotten,Splamiony Zapomniany,Tainted Forgotten,Tainted Forgotten,The Forgotten is an immobile bone pile that is picked up and thrown by The Soul for 3x damage#Only The Soul can take damage#Bombs are placed at Forgotten's location#Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts,Tainted Forgotten,El Olvidado Corrupto,Tainted Forgotten,Tainted Forgotten,The Forgotten là một đống xương bất động được The Soul nhặt và ném gây sát thương gấp 3#Chỉ The Soul có thể nhận sát thương#Bom được đặt tại vị trí của Forgotten#Không thể có Trái tim đỏ#{{SoulHeart}} Tăng máu tặng Trái tim hồn,Tainted Forgotten,1
+489,The Zealot,Tainted Bethany,Character,더럽혀진 베서니,Tainted Bethany,Tainted Bethany,Tainted Bethany,Tainted Bethany,Tainted Bethany,Béthanie Impure,Tainted Bethany,赤ハートを持てない 代わりにアクティブ アイテムのチャージ として使用できる#体力が増える効果は、 代わりに青ハート+1と チャージ+12を得る#ステータスアップの 効果が75%に抑制される,Tainted Bethany,Splamiona Betania,Tainted Bethany,Tainted Bethany,{{Heart}} Use Red Hearts to charge your active item#Can't have Red Hearts#{{SoulHeart}} Health ups grant Soul Hearts and blood charges#Stat increases are only 75% effective,Tainted Bethany,Bethany Corrupta,Tainted Bethany,Tainted Bethany,{{Heart}} Dùng Trái tim đỏ để nạp vật phẩm hoạt động#Không thể có Trái tim đỏ#{{SoulHeart}} Tăng máu tặng Trái tim hồn và lần nạp máu#Tăng chỉ số chỉ hiệu quả 75%,Tainted Bethany,1
+490,The Deserter,Tainted Jacob,Character,더럽혀진 야곱과 에사우,Tainted Jacob,Tainted Jacob,Tainted Jacob,Tainted Jacob,Tainted Jacob,Jacob Impur,Tainted Jacob,敵対化したエサウが ヤコブを追い回す#接近すると、エサウが 突進を始め、進路上の 敵に大ダメージを与える#エサウと接触すると、 ヤコブは次のフロアまで ザ・ロスト状態になる#ロスト時、悪魔取引が 一回無料になる,Tainted Jacob,Splamiony Jakub,Tainted Jacob,Tainted Jacob,"Dark Esau chases you, charging towards you when close#The charge does a lot of damage to enemies#If he hits you, you turn into a ghost that dies in one hit for the rest of the floor#While a ghost, one devil deal per room can be taken for free",Tainted Jacob,Jacob Corrupto,Tainted Jacob,Tainted Jacob,"Dark Esau đuổi theo bạn, lao về phía bạn khi gần#Đòn lao gây nhiều sát thương cho kẻ thù#Nếu trúng bạn, bạn biến thành ma chết trong một phát cho đến hết tầng#Khi là ma, mỗi phòng có thể lấy một giao kèo quỷ miễn phí",Tainted Jacob,1
+491,Glitched Crown,Glitched Crown,Item,글리치 왕관,Glitched Crown,Poškozená Koruna,Geflickte Krone,Glitched Crown,Glitched Crown,Couronne Corrompue,Corona Glitchata,バグったクラウン,Glitched Crown,Zglitchowana Korona,Glitched Crown,Glitched Crown,Coroană Glichuită,Глючная корона,Corona Glitcheada,Hatalı Taç,Глючна корона,Glitched Crown,错误王冠,1
+492,Belly Jelly,Belly Jelly,Item,벨리 젤리,Belly Jelly,Břišní Želé,Bauchgelee,Belly Jelly,Belly Jelly,Haricot Confit,Gelatina di Fagiolo,ベリー ジェリー,Belly Jelly,Belly Jelly,Belly Jelly,Belly Jelly,Belly Jelly,Жевательное драже,Belly Jelly,Göbek Jelatini,Желейка,Belly Jelly,肚肚软糖,1
+493,Blue Key,Blue Key,Trinket,푸른 열쇠,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,Blue Key,1
+494,Sanguine Bond,Sanguine Bond,Item,핏빛 결속,Sanguine Bond,Krvežíznivé Pouto,Sanguine Bindung,Sanguine Bond,Sanguine Bond,Pacte de Sang,Legame di Sangue,サングイン ボンド,Sanguine Bond,Krwista więź,Sanguine Bond,Sanguine Bond,Legătură de Sânge,Кровавые узы,Vínculo de Sangre,Kan Bağı,Кривавий зв'язок,Sanguine Bond,血色羁绊,1
+495,The Swarm,The Swarm,Item,파리 군단,The Swarm,Roj,Der Schwarm,The Swarm,The Swarm,La Nuée,Lo Sciame,ザ スウォーム,The Swarm,rój,The Swarm,The Swarm,Roiul,Рой,El Enjambre,Sürü,Рій,The Swarm,虫群,1
+496,Heartbreak,Heartbreak,Item,비탄,Heartbreak,Zlomené Srdce,Herzschmerz,Heartbreak,Heartbreak,Brise-Cœur,Crepacuore,ハートブレイク,Heartbreak,złamane serce,Heartbreak,Heartbreak,Rănit în Dragoste,Горе,Corazón Roto,Kalp Kırıklığı,Розрив серця,Heartbreak,心碎,1
+497,Larynx,Larynx,Item,후두,Larynx,Hrtan,Kehlkopf,Larynx,Larynx,Larynx,Laringe,ラリンクス,Larynx,Larynx,Larynx,Larynx,Laringe,Глотка,Laringe,Gırtlak,Гортань,Larynx,声带,1
+498,Azazel's Rage,Azazel's Rage,Item,아자젤의 분노,Azazel's Rage,Azazelův Hněv,Azazels Zorn,Azazel's Rage,Azazel's Rage,Rage d'Azazel,Furia di Azazel,アザゼルの怒り,Azazel's Rage,Wściekłośc Azazela,Azazel's Rage,Azazel's Rage,Furia lui Azazel,Ярость Азазеля,La Ira de Azazel,Azazel'in Siniri,Лють Азазеля,Azazel's Rage,阿撒泻勒之怒,1
+499,Salvation,Salvation,Item,구원,Salvation,Spása,Heilung,Salvation,Salvation,Salvation,Salvezza,救済,Salvation,Salvation,Salvation,Salvation,Mântuire,Спасение,Salvación,Kurtuluş,Спасіння,Salvation,救恩,1
+500,TMTRAINER,TMTRAINER,Item,,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,バグ技,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,TMTRAINER,ТМТРЕЙНЕР,TMTRAINER,TMTRAINER,ТМТРЕЙНЕР,TMTRAINER,错误技,1
+501,Sacred Orb,Sacred Orb,Item,성스러운 오브,Sacred Orb,Posvátný Orb,Heilige Kugel,Sacred Orb,Sacred Orb,Orbe Sacré,Sfera Sacra,セイクリッド オーブ,Sacred Orb,Sacred Orb,Sacred Orb,Sacred Orb,Glob Sacru,Священный шар,Orbe Sagrado,Kutsal Küre,Священна куля,Sacred Orb,十字圣球,1
+502,Twisted Pair,Twisted Pair,Item,뒤틀린 한 쌍,Twisted Pair,Zvrácený Pár,Verdrehtes Paar,Twisted Pair,Twisted Pair,Jumeaux Malicieux,Diabolico Duo,ツイステッド ペア,Twisted Pair,Pokręcona para,Twisted Pair,Twisted Pair,Pereche Răsucită,Нечестивая парочка,Par Retorcido,Dönen İkili,Химерна парочка,Twisted Pair,作孽双子,1
+503,Strawman,Strawman,Item,밀짚인형,Strawman,Slamák,Strohmann,Strawman,Strawman,Gardien en Peluche,Fantoccio,ストローマン,Strawman,Straszydło,Strawman,Strawman,Sperietoare,Соломенное чучело,Hombre de Paja,Korkuluk,Опудало,Strawman,稻草人,1
+504,Echo Chamber,Echo Chamber,Item,반향효과,Echo Chamber,Echo Komora,Echo-Kammer,Echo Chamber,Echo Chamber,Résonance,Camera di Risonanza,エコー チェンバー,Echo Chamber,Echo Komnata,Echo Chamber,Echo Chamber,Ecou,Эхо-камера,Cámara de Eco,Eko Çemberi,Ехокамера,Echo Chamber,回声室,1
+505,Isaac's Tomb,Isaac's Tomb,Item,아이작의 무덤,Isaac's Tomb,Izákova Hrobka,Isaacs Grab,Isaac's Tomb,Isaac's Tomb,Tombeau d'Isaac,Tomba di Isaac,アイザックの墓,Isaac's Tomb,Grobowiec Isaaca,Isaac's Tomb,Isaac's Tomb,Sarcofagul lui Isaac,Гробница Исаака,La Tumba de Isaac,Isaac'in Mezarı,Айзекова могила,Isaac's Tomb,以撒的坟墓,1
+506,Vengeful Spirit,Vengeful Spirit,Item,복수심의 영혼,Vengeful Spirit,Pomstychtivá Duše,Racheerfüllter Geist,Vengeful Spirit,Vengeful Spirit,Esprit Vengeur,Spirito Vendicativo,生霊,Vengeful Spirit,Mściwy duch,Vengeful Spirit,Vengeful Spirit,Spirit Răzbunător,Мстительный дух,Espíritu de venganza,İntikam Ruhu,Мстивий дух,Vengeful Spirit,复仇之魂,1
+507,Esau Jr.,Esau Jr.,Item,에사우 주니어,Esau Jr.,Ezau ml.,Esau Jr.,Esau Jr.,Esau Jr.,Ésaü Junior,Esau Jr.,エサウ Jr.,Esau Jr.,Esau Jr.,Esau Jr.,Esau Jr.,Esau Jr.,Исав Младший,Esau Junior,Esau Jr.,Ісав молодший,Esau Jr.,小以扫,1
+508,Bloody Mary,Bloody Mary,None,unlock challenge,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,Bloody Mary,1
+509,Baptism by Fire,Baptism by Fire,None,unlock challenge,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,Baptism by Fire,1
+510,Isaac's Awakening,Isaac's Awakening,None,unlock challenge,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,Isaac's Awakening,1
+511,Seeing Double,Seeing Double,None,unlock challenge,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,Seeing Double,1
+512,Pica Run,Pica Run,None,unlock challenge,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,Pica Run,1
+513,Hot Potato,Hot Potato,None,unlock challenge,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,Hot Potato,1
+514,Cantripped!,Cantripped!,None,unlock challenge,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,Cantripped!,1
+515,Red Redemption,Red Redemption,None,unlock challenge,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,Red Redemption,1
+516,DELETE THIS,DELETE THIS,None,,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,DELETE THIS,1
+517,Dirty Mind,Dirty Mind,Item,더러운 군집,Dirty Mind,Špinavá Mysl,Schmutziger Verstand,Dirty Mind,Dirty Mind,Coprophilie,Mente Sporca,ダーティ マインド,Dirty Mind,Brudne myśli,Dirty Mind,Dirty Mind,Minte Murdară,Грязные мысли,Mente sucia,Pis Akıl,Брудні думки,Dirty Mind,龌龊之心,1
+518,Sigil of Baphomet,Sigil of Baphomet,Trinket,바포메트의 인장,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,Sigil of Baphomet,1
+519,Purgatory,Purgatory,Item,연옥,Purgatory,Očistec,Fegefeuer,Purgatory,Purgatory,Purgatoire,Purgatorio,パーガトリー,Purgatory,Czyściec,Purgatory,Purgatory,Purgatoriu,Чистилище,Purgatorio,Araf,Чистилище,Purgatory,炼狱恶鬼,1
+520,Spirit Sword,Spirit Sword,Item,영혼검,Spirit Sword,Duchovní Meč,Geistschwert,Spirit Sword,Spirit Sword,Épée de l'Esprit,Spada dello Spirito,スピリット ソード,Spirit Sword,Duchowe ostrze,Spirit Sword,Spirit Sword,Sabie Spirit,Духовный меч,Espada espiritual,Ruh Kılıcı,Меч Духа,Spirit Sword,英灵剑,1
+521,Broken Glasses,Broken Glasses,Trinket,깨진 안경,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,Broken Glasses,1
+522,Ice Cube,Ice Cube,Trinket,얼음 큐브,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,Ice Cube,1
+523,Charged Penny,Charged Penny,Trinket,충전된 동전,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,Charged Penny,1
+524,The Fool,The Fool?,Card,바보?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,The Fool?,1
+525,The Magician,The Magician?,Card,마법사?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,The Magician?,1
+526,The High Priestess,The High Priestess?,Card,여교황?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,The High Priestess?,1
+527,The Empress,The Empress?,Card,여제?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,The Empress?,1
+528,The Emperor,The Emperor?,Card,황제?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,The Emperor?,1
+529,The Hierophant,The Hierophant?,Card,교황?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,The Hierophant?,1
+530,The Lovers,The Lovers?,Card,연인?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,The Lovers?,1
+531,The Chariot,The Chariot?,Card,전차?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,The Chariot?,1
+532,Justice,Justice?,Card,정의?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,Justice?,1
+533,The Hermit,The Hermit?,Card,은둔자?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,The Hermit?,1
+534,Wheel of Fortune,Wheel of Fortune?,Card,운명의 수레바퀴?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,Wheel of Fortune?,1
+535,Strength,Strength?,Card,힘?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,Strength?,1
+536,The Hanged Man,The Hanged Man?,Card,매달린 남자?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,The Hanged Man?,1
+537,Death,Death?,Card,죽음?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,Death?,1
+538,Temperance,Temperance?,Card,절제?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,Temperance?,1
+539,The Devil,The Devil?,Card,악마?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,The Devil?,1
+540,The Tower,The Tower?,Card,탑?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,The Tower?,1
+541,The Stars,The Stars?,Card,별?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,The Stars?,1
+542,The Sun and the Moon,"The Sun?,the Moon?",Card,"해?,달?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?","The Sun?,the Moon?",1
+543,Judgement,Judgement?,Card,심판?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,Judgement?,1
+544,The World,The World?,Card,세계?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,The World?,1
+545,Old Capacitor,Old Capacitor,Trinket,오래된 축전기,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,Old Capacitor,1
+546,Brimstone Bombs,Brimstone Bombs,Item,유황불 폭탄,Brimstone Bombs,Brimstonové Bomby,Schwefelbomben,Brimstone Bombs,Brimstone Bombs,Bombes Sulfureuses,Bombe Zolfo Fuso,ブリムストーン ボム,Brimstone Bombs,Bomby Brimstonowe,Brimstone Bombs,Brimstone Bombs,Bombe Brimstone,Серные бомбы,Bombas de azufre,Brimstone Bombası,Сірчані бомби,Brimstone Bombs,硫磺火炸弹,1
+547,Mega Mush,Mega Mush,Item,거대버섯,Mega Mush,Mega Houba,Mega-Pilz,Mega Mush,Mega Mush,Méga Champi,Mega Fungo,メガ　マッシュ,Mega Mush,Mega grzyb,Mega Mush,Mega Mush,Mega Ciupercă,Мегагриб,Mega seta,Mega Mantar,Мегагриб,Mega Mush,超级蘑菇,1
+548,Mom's Lock,Mom's Lock,Trinket,엄마의 머리뭉치,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,Mom's Lock,1
+549,Dice Bag,Dice Bag,Trinket,주사위 가방,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,Dice Bag,1
+550,Holy Crown,Holy Crown,Trinket,신성한 왕관,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,Holy Crown,1
+551,Mother's Kiss,Mother's Kiss,Trinket,어머니의 키스,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,Mother's Kiss,1
+552,Gilded Key,Gilded Key,Trinket,도금 열쇠,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,Gilded Key,1
+553,Lucky Sack,Lucky Sack,Trinket,복주머니,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,Lucky Sack,1
+554,Your Soul,Your Soul,Trinket,네 영혼,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,Your Soul,1
+555,Number Magnet,Number Magnet,Trinket,숫자 자석,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,Number Magnet,1
+556,Dingle Berry,Dingle Berry,Trinket,딩글 베리,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,Dingle Berry,1
+557,Ring Cap,Ring Cap,Trinket,딱총 화약,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,Ring Cap,1
+558,Strange Key,Strange Key,Trinket,이상한 열쇠,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,Strange Key,1
+559,Lil Clot,Lil Clot,Trinket,꼬마 클롯,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,Lil Clot,1
+560,Temporary Tattoo,Temporary Tattoo,Trinket,스티커 문신,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,Temporary Tattoo,1
+561,Swallowed M80,Swallowed M80,Trinket,삼킨 M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,Swallowed M80,1
+562,Wicked Crown,Wicked Crown,Trinket,사악한 왕관,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,Wicked Crown,1
+563,Azazel's Stump,Azazel's Stump,Trinket,아자젤의 뿔대,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,Azazel's Stump,1
+564,Torn Pocket,Torn Pocket,Trinket,찢어진 주머니,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,Torn Pocket,1
+565,Torn Card,Torn Card,Trinket,찢어진 카드,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,Torn Card,1
+566,Nuh Uh!,Nuh Uh!,Trinket,아니거든!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,Nuh Uh!,1
+567,Modeling Clay,Modeling Clay,Trinket,조형 찰흙,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,Modeling Clay,1
+568,Kid's Drawing,Kid's Drawing,Trinket,아이의 그림,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,Kid's Drawing,1
+569,Crystal Key,Crystal Key,Trinket,수정 열쇠,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,Crystal Key,1
+570,The Twins,The Twins,Trinket,쌍둥이,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,The Twins,1
+571,Adoption Papers,Adoption Papers,Trinket,입양 서류,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,Adoption Papers,1
+572,Keeper's Bargain,Keeper's Bargain,Trinket,키퍼의 흥정,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,Keeper's Bargain,1
+573,Cursed Penny,Cursed Penny,Trinket,저주받은 동전,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,Cursed Penny,1
+574,Cricket Leg,Cricket Leg,Trinket,귀뚜라미 다리,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,Cricket Leg,1
+575,Apollyon's Best Friend,Apollyon's Best Friend,Trinket,아폴리온의 절친,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,Apollyon's Best Friend,1
+576,Polished Bone,Polished Bone,Trinket,연마한 뼈,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,Polished Bone,1
+577,Hollow Heart,Hollow Heart,Trinket,텅 빈 심장,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,Hollow Heart,1
+578,Expansion Pack,Expansion Pack,Trinket,확장팩,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,Expansion Pack,1
+579,Beth's Essence,Beth's Essence,Trinket,베다니의 정수,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,Beth's Essence,1
+580,RC Remote,RC Remote,Trinket,RC 리모콘,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,RC Remote,1
+581,Found Soul,Found Soul,Trinket,되찾은 영혼,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,Found Soul,1
+582,Member Card,Member Card,Item,멤버쉽 카드,Member Card,Členská Karta,Mitgliedskarte,Member Card,Member Card,Carte de Membre,Tessera Membri,メンバー カード,Member Card,Karta Członkowska,Member Card,Member Card,Card de Membru,Членская карточка,Tarjeta de Socio,Üye Kartı,Членська карта,Member Card,会员卡,1
+583,Golden Razor,Golden Razor,Item,황금 면도날,Golden Razor,Zlatá Žiletka,Goldenes Rasiermesser,Golden Razor,Golden Razor,Lame de Rasoir Dorée,Lametta Dorata,ゴールデン レイザー,Golden Razor,Złota żyletka,Golden Razor,Golden Razor,Brici de Aur,Золотая бритва,Cuchilla dorada,Altın Jilet,Золота бритва,Golden Razor,金剃刀片,1
+584,Spindown Dice,Spindown Dice,Item,스핀다운 주사위,Spindown Dice,Roztáčející Kostka,Spindown-Würfel,Spindown Dice,Spindown Dice,Dé Compteur,Dado Decrementale,スピンダウン ダイス,Spindown Dice,Spindown Dice,Spindown Dice,Spindown Dice,Zar Coborâtor,Кубик с вычетом,Dado Reductor,AltÇevir Zarı,Кубик прокрутки,Spindown Dice,计数二十面骰,1
+585,Hypercoagulation,Hypercoagulation,Item,과응고,Hypercoagulation,Hyperkoagulace,Hyperkoagulation,Hypercoagulation,Hypercoagulation,Hypercoagulation,Trombofilia,ハイパーコアギュレイション,Hypercoagulation,Nadkrzepliwość,Hypercoagulation,Hypercoagulation,Hipercoagulare,Гиперкоагуляция,Hipercoagulación,Hypercoagulation,Гіперкоагуляція,Hypercoagulation,高凝血,1
+586,Bag of Crafting,Bag of Crafting,Item,조합 가방,Bag of Crafting,Craftovací Pytlík,Tasche des Handwerks,Bag of Crafting,Bag of Crafting,Sac de Fabrication,Sacco del Fai da Te,バッグ オブ クラフティング,Bag of Crafting,Torba tworzenia,Bag of Crafting,Bag of Crafting,Geantă de Meșteșuguri,Мешок создания,Bolsa de Trabajo,Elişi Çantası,Сумка для рукоділля,Bag of Crafting,合成宝袋,1
+587,Dark Arts,Dark Arts,Item,흑마술,Dark Arts,Temné Umění,Dunkle Künste,Dark Arts,Dark Arts,Arts Obscurs,Arti Oscure,ダーク アーツ,Dark Arts,Mroczne Techniki,Dark Arts,Dark Arts,Artă Negre,Тёмные силы,Artes Oscuras,Karanlık Sanatlar,Темні мистецтва,Dark Arts,暗仪刺刀,1
+588,IBS,IBS,Item,,IBS,Syndrom Dráždivého Střeva,IBS,IBS,IBS,Intestin Irrité,Sindrome del Colon Irritabile,IBS,IBS,IBS,IBS,IBS,SII,СРК,IBS,IBS,СПК,IBS,大肠激躁症,1
+589,Sumptorium,Sumptorium,Item,섬토리움,Sumptorium,Sumptorium,Sumptorium,Sumptorium,Sumptorium,Sumptorium,Sumptorium,サンプトリウム,Sumptorium,Sumptorium,Sumptorium,Sumptorium,Sumptorium,Свищ,Sumptorium,Sumptorium,Сумпторіум,Sumptorium,圣血吸管,1
+590,Berserk!,Berserk!,Item,폭주!,Berserk!,Zběsilost!,Berserker!,Berserk!,Berserk!,Frénésie,Violenza!,バーサーカー,Berserk!,Berserk!,Berserk!,Berserk!,Berserk!,Берсерк!,¡Berserker!,Çılgınlık!,Берсерк!,Berserk!,狂怒！,1
+591,Hemoptysis,Hemoptysis,Item,각혈,Hemoptysis,Funguje s {1},Hämoptysis,Hemoptysis,Hemoptysis,Synergise avec {1},Funziona con {1},{1}の呪い有効,Hemoptysis,Krwioplucoe,Hemoptysis,Hemoptysis,Works with {1},Кровохарканье,Funciona con {1},Hemoptysis,Кровохаркання,Hoạt động với {1},{1}有效,1
+592,Flip,Flip,Item,뒤집기,Flip,Převrácení,Wenden,Flip,Flip,Inversion,Limbo,フリップ,Flip,Flip,Flip,Flip,Flip,Кувырок,Cambio,Çevir,Перевернись,Flip,生死逆转,1
+593,Corrupted Data,Corrupted Data,Other,커럽티드 데이터(깨진 아이템),Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,Corrupted Data,1
+594,Ghost Bombs,Ghost Bombs,Item,유령 폭탄,Ghost Bombs,Strašidelné Bomby,Geisterbomben,Ghost Bombs,Ghost Bombs,Bombes Fantômes,Bombe Fantasma,ゴースト ボム,Ghost Bombs,Duchowe bomby,Ghost Bombs,Ghost Bombs,Bombe Fantome,Призрачные бомбы,Bombas Fantasma,Hayalet Bomba,Бомби-привиди,Ghost Bombs,幽灵炸弹,1
+595,Gello,Gello,Item,겔로,Gello,Gello,Gello,Gello,Gello,Gello,Gellò,ゲロー,Gello,Gello,Gello,Gello,Gello,Гелло,Gello,Gello,Гелло,Gello,格罗,1
+596,Keeper's Kin,Keeper's Kin,Item,키퍼의 친척,Keeper's Kin,Keeperovi Příbuzní,Keepers Sippe,Keeper's Kin,Keeper's Kin,Amies du Gardien,Strirpe del Mercante,キーパーズ キン,Keeper's Kin,Rodzinka keepera,Keeper's Kin,Keeper's Kin,Ruda lui Keeper,Родня Хранителя,Parientes de Keeper,Keeper'ın akrabası,Рідня Хранителя,Keeper's Kin,店主的亲友,1
+597,Abyss,Abyss,Item,무저갱,Abyss,Hlubina,Abyss,Abyss,Abyss,Abysse,Abisso,アビス,Abyss,Otchłań,Abyss,Abyss,Abyss,Бездна,Abismo,Boşluk,Безодня,Abyss,无底坑,1
+598,Decap Attack,Decap Attack,Item,참수 공격,Decap Attack,Bezhlavý Útok,Enthauptungsangriff,Decap Attack,Decap Attack,Décapitation,Decapita Azione,デカップ アタック,Decap Attack,Dakapito atak,Decap Attack,Decap Attack,Atac Decapitat,Голову с плеч,Ataque Decapitado,Kafa Koparma Atağı,Голову з пліч,Decap Attack,飞头攻击,1
+599,Lemegeton,Lemegeton,Item,마도서 레메게톤,Lemegeton,Lemegeton,Lemegeton,Lemegeton,Lemegeton,Lemegeton,Lemegeton,レメゲトン,Lemegeton,Lemegeton,Lemegeton,Lemegeton,Lemegeton,Лемегетон,Lemegeton,Lemegeton,Лемеґетон,Lemegeton,所罗门魔典,1
+600,Anima Sola,Anima Sola,Item,아니마 솔라,Anima Sola,Osamělá Duše,Anima Sola,Anima Sola,Anima Sola,Anima Sola,Anima Sola,アニマ ソラ,Anima Sola,Anima Sola,Anima Sola,Anima Sola,Anima Sola,Анима сола,Anima Sola,Anima Sola,Аніма Сола,Anima Sola,孤魂铁索,1
+601,Mega Chest,Mega Chest,Pickup,메가 상자,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,Mega Chest,1
+602,Queen of Hearts,Queen of Hearts,Card,하트 퀸,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,Queen of Hearts,1
+603,Gold Pill,Gold Pill,Pickup,황금 알약,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,Gold Pill,1
+604,Black Sack,Black Sack,Pickup,검은 보따리,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,Black Sack,1
+605,Charming Poop,Charming Poop,Other,패밀리어 소환하는 똥,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,Charming Poop,1
+606,Horse Pill,Horse Pill,Pill,말약,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,Horse Pill,1
+607,Crane Game,Crane Game,Other,크레인 게임,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,Crane Game,1
+608,Hell Game,Hell Game,Other,악마 야바위꾼,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,Hell Game,1
+609,Wooden Chest,Wooden Chest,Pickup,나무 상자,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,Wooden Chest,1
+610,Wild Card,Wild Card,Card,와일드 카드,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,Wild Card,1
+611,Haunted Chest,Haunted Chest,Pickup,유령 상자,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,Haunted Chest,1
+612,Fool's Gold,Fool's Gold,Other,돈 박힌 돌,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,Fool's Gold,1
+613,Golden Penny,Golden Penny,Pickup,골든 페니,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,Golden Penny,1
+614,Rotten Beggar,Rotten Beggar,Other,썩은 거지,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,Rotten Beggar,1
+615,Golden Battery,Golden Battery,Pickup,황금 배터리(데미지입는거),Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,Golden Battery,1
+616,Confessional,Confessional,Other,고해실,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,Confessional,1
+617,Golden Trinket,Golden Trinket,Other,황금 장신구 등장,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,Golden Trinket,1
+618,Soul of Isaac,Soul of Isaac,Rune,아이작의 영혼,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,Soul of Isaac,1
+619,Soul of Magdalene,Soul of Magdalene,Rune,막달레나의 영혼,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,Soul of Magdalene,1
+620,Soul of Cain,Soul of Cain,Rune,카인의 영혼,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,Soul of Cain,1
+621,Soul of Judas,Soul of Judas,Rune,유다의 영혼,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,Soul of Judas,1
+622,Soul of???,Soul of ???,Rune,???의 영혼,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,Soul of ???,1
+623,Soul of Eve,Soul of Eve,Rune,이브의 영혼,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,Soul of Eve,1
+624,Soul of Samson,Soul of Samson,Rune,삼손의 영혼,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,Soul of Samson,1
+625,Soul of Azazel,Soul of Azazel,Rune,아자젤의 영혼,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,Soul of Azazel,1
+626,Soul of Lazarus,Soul of Lazarus,Rune,나사로의 영혼,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,Soul of Lazarus,1
+627,Soul of Eden,Soul of Eden,Rune,에덴의 영혼,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,Soul of Eden,1
+628,Soul of the Lost,Soul of the Lost,Rune,로스트의 영혼,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,Soul of the Lost,1
+629,Soul of Lilith,Soul of Lilith,Rune,릴리스의 영혼,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,Soul of Lilith,1
+630,Soul of the Keeper,Soul of the Keeper,Rune,키퍼의 영혼,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,Soul of the Keeper,1
+631,Soul of Apollyon,Soul of Apollyon,Rune,아폴리온의 영혼,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,Soul of Apollyon,1
+632,Soul of the Forgotten,Soul of the Forgotten,Rune,포가튼의 영혼,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,Soul of the Forgotten,1
+633,Soul of Bethany,Soul of Bethany,Rune,베서니의 영혼,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,Soul of Bethany,1
+634,Soul of Jacob and Esau,Soul of Jacob and Esau,Rune,야곱과 에사우의 영혼,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,Soul of Jacob and Esau,1
+635,A Strange Door,A Strange Door,Map,비스트 루트로 가는 문,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,A Strange Door,1
+636,Death Certificate,Death Certificate,Item,사망 증명서,Death Certificate,Úmrtní List,Totenschein,Death Certificate,Death Certificate,Acte de Décès,Certificato di Morte,死亡届,Death Certificate,Certyfikat śmierci,Death Certificate,Death Certificate,Certificat de Deces,Свидетельство о смерти,Certificado de Defunción,Ölüm Sertifikası,Свідоцтво про смерть,Death Certificate,死亡证明,1
+637,Dead God,Dead God,None,,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,Dead God,1
+638,Play Online,Play Online,None,,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,Play Online,1
+639,Win Online,Win Online,None,,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,Win Online,1
+640,Win Online Daily,Win Online Daily,None,,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,Win Online Daily,1


### PR DESCRIPTION
## Summary
- add a persistent language selector that reads localized strings and updates item, secret, and challenge trees
- allow toggling red highlights for locked items and keep the preference in settings
- extend ui_secrets.csv with localized unlock names across the shipped language packs

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d553b76ea88332802e02a7a2852bae