### PR TITLE
Improve focus suppression for category buttons

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -65,10 +65,10 @@ def _style_code():
     if sys.platform == "win32":
        style.theme_use('winnative')
     focus_free_styles = [
-        'TNotebook.Tab', 'TNotebook', 'Notebook.Tab', 'Notebook', 'TButton',
-        'Button', 'Toolbutton', 'TCheckbutton', 'TRadiobutton', 'TMenubutton',
-        'TCombobox', 'TEntry', 'Horizontal.TScrollbar', 'Vertical.TScrollbar',
-        'Treeview', 'Treeview.Item'
+        'TNotebook.Tab', 'TNotebook', 'TButton', 'Toolbutton', 'TCheckbutton',
+        'TRadiobutton', 'TMenubutton', 'TCombobox', 'TEntry',
+        'Horizontal.TScrollbar', 'Vertical.TScrollbar', 'Treeview',
+        'Treeview.Item'
     ]
     for style_name in focus_free_styles:
         try:

--- a/gui.py
+++ b/gui.py
@@ -65,10 +65,10 @@ def _style_code():
     if sys.platform == "win32":
        style.theme_use('winnative')
     focus_free_styles = [
-        'TNotebook.Tab', 'TNotebook', 'TButton', 'Toolbutton', 'TCheckbutton',
-        'TRadiobutton', 'TMenubutton', 'TCombobox', 'TEntry',
-        'Horizontal.TScrollbar', 'Vertical.TScrollbar', 'Treeview',
-        'Treeview.Item'
+        'TNotebook.Tab', 'TNotebook', 'Notebook.Tab', 'Notebook', 'TButton',
+        'Button', 'Toolbutton', 'TCheckbutton', 'TRadiobutton', 'TMenubutton',
+        'TCombobox', 'TEntry', 'Horizontal.TScrollbar', 'Vertical.TScrollbar',
+        'Treeview', 'Treeview.Item'
     ]
     for style_name in focus_free_styles:
         try:


### PR DESCRIPTION
## Summary
- expand focus suppression in the new Tk UI to scan actual widget styles and strip focus elements dynamically
- include default and Windows button/notebook style variants in the legacy gui to avoid dotted outlines on category selectors

## Testing
- python -m compileall isaac_editor.py gui.py

------
https://chatgpt.com/codex/tasks/task_e_68d58fb1ce688332963bfc4b8708ac43