### PR TITLE
Disable tree view focus to remove dotted outlines

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -1735,6 +1735,10 @@ class IsaacSaveEditor(tk.Tk):
 
     def _create_completion_tree(self, container: ttk.Frame) -> IconCheckboxTreeview:
         tree = IconCheckboxTreeview(container, columns=(), show="tree", selectmode="none")
+        try:
+            tree.configure(takefocus=0)
+        except tk.TclError:
+            pass
         tree.grid(column=0, row=0, sticky="nsew")
         yscroll = ttk.Scrollbar(container, orient="vertical", command=tree.yview)
         yscroll.grid(column=1, row=0, sticky="ns")
@@ -1758,6 +1762,10 @@ class IsaacSaveEditor(tk.Tk):
             selectmode="none",
             icon_mode=icon_mode,
         )
+        try:
+            tree.configure(takefocus=0)
+        except tk.TclError:
+            pass
         tree.grid(column=0, row=0, sticky="nsew")
         yscroll = ttk.Scrollbar(container, orient="vertical", command=tree.yview)
         yscroll.grid(column=1, row=0, sticky="ns")


### PR DESCRIPTION
## Summary
- prevent the completion and item tree views from receiving focus so dotted focus rectangles no longer appear on category rows

## Testing
- python -m py_compile isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d594d220dc83329c9fa5e45e5c6c31