### PR TITLE
Adjust focus suppression and checkbox label sizing

### DIFF
--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -168,7 +168,7 @@ def _suppress_focus_indicators(root: tk.Misc) -> None:
             if value:
                 focus_background = value
                 break
-        configure: dict[str, object] = {"focuswidth": 0}
+        configure: dict[str, object] = {"focuswidth": 0, "focusthickness": 0}
         if focus_background:
             configure["focuscolor"] = focus_background
         try:
@@ -180,6 +180,9 @@ def _suppress_focus_indicators(root: tk.Misc) -> None:
                 style.map(
                     style_name,
                     focuscolor=[("!focus", focus_background), ("focus", focus_background)],
+                    bordercolor=[("!focus", focus_background), ("focus", focus_background)],
+                    lightcolor=[("!focus", focus_background), ("focus", focus_background)],
+                    darkcolor=[("!focus", focus_background), ("focus", focus_background)],
                 )
             except tk.TclError:
                 pass
@@ -496,8 +499,6 @@ class IsaacSaveEditor(tk.Tk):
             ttk.Label,
             tk.Button,
             ttk.Button,
-            tk.Checkbutton,
-            ttk.Checkbutton,
             ttk.Combobox,
         )
 


### PR DESCRIPTION
## Summary
- expand the focus normalization routine to zero out ttk focus widths and recolor additional focus-related elements
- stop resizing ttk checkbuttons automatically so highlight toggle text remains visible

## Testing
- python -m compileall isaac_editor.py

------
https://chatgpt.com/codex/tasks/task_e_68d59644b6108332a4dd6db7578a01e2