### PR TITLE
Fix checkbox text removal in GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -23,10 +23,6 @@ def _strip_focus_elements(layout):
     cleaned_layout = []
     for element, options in layout:
         if 'focus' in element.lower():
-            if isinstance(options, dict) and 'children' in options:
-                cleaned_layout.extend(
-                    _strip_focus_elements(options.get('children', ()))
-                )
             continue
         new_options = dict(options)
         if 'children' in new_options:

--- a/isaac_editor.py
+++ b/isaac_editor.py
@@ -61,6 +61,10 @@ def _strip_focus_elements(layout: list[tuple[str, dict]]) -> list[tuple[str, dic
     cleaned: list[tuple[str, dict]] = []
     for element, options in layout:
         if "focus" in element.lower():
+            if isinstance(options, dict):
+                children = options.get("children")
+                if isinstance(children, (list, tuple)):
+                    cleaned.extend(_strip_focus_elements(list(children)))
             continue
         new_options = dict(options)
         children = new_options.get("children")


### PR DESCRIPTION
## Summary
- ensure focus-stripping helper preserves label children so ttk checkbuttons keep their text

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5996cb3308332bf1f2ad1ac49a539