### PR TITLE
Fix language selector label to stay in English

### DIFF
--- a/isaac_savefile_editor.py
+++ b/isaac_savefile_editor.py
@@ -1287,9 +1287,9 @@ class IsaacSaveEditor(tk.Tk):
             "Set Donation/Greed/Eden Tokens to 999",
         )
 
-        language_label = ttk.Label(auto_999_frame)
+        language_label = ttk.Label(auto_999_frame, text="Language")
         language_label.grid(column=2, row=0, sticky="e", padx=(10, 0))
-        self._register_text(language_label, "언어", "Language")
+        self._adjust_widget_width(language_label, "Language")
 
         language_box = ttk.Combobox(
             auto_999_frame,


### PR DESCRIPTION
## Summary
- display the language selector label as the fixed English text "Language"
- adjust the label width manually since it is no longer part of the translation system

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d88fa161c88332bc6e834d4a9e295e