### PR TITLE
Adjust Eden token byte width

### DIFF
--- a/isaac_savefile_editor.py
+++ b/isaac_savefile_editor.py
@@ -924,7 +924,7 @@ class IsaacSaveEditor(tk.Tk):
                 "offset": 0x50,
                 "title": ("에덴 토큰", "Eden Tokens"),
                 "description": ("에덴 토큰", "Eden Tokens"),
-                "num_bytes": 4,
+                "num_bytes": 2,
             },
         }
         self._numeric_order: List[str] = ["donation", "greed", "streak", "eden"]


### PR DESCRIPTION
## Summary
- update the Eden token numeric configuration to use a 2-byte field so upper bytes remain untouched when editing

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d96e23a73083329480c553b76f6e41