### PR TITLE
Add stats tab and bestiary editing, fix numeric handling

### DIFF
--- a/script.py
+++ b/script.py
@@ -298,15 +298,22 @@ def alterItem(data, item_index, unlock=True):
         val = 0
     return alterInt(data, getSectionOffsets(data)[3]+item_index, val, num_bytes=1)
 
-def alterInt(data, offset, new_val, debug=False, num_bytes=2):
+def alterInt(data, offset, new_val, debug=False, num_bytes=2, signed=False):
     if debug:
-        print(f"current value: {int.from_bytes(data[offset:offset+num_bytes], 'little')}")
+        current_val = int.from_bytes(
+            data[offset:offset+num_bytes], 'little', signed=signed
+        )
+        print(f"current value: {current_val}")
         print(f"new value: {new_val}")
-    return data[:offset] + new_val.to_bytes(num_bytes, 'little', signed=True) + data[offset + num_bytes:]
+    return data[:offset] + int(new_val).to_bytes(num_bytes, 'little', signed=signed) + data[offset + num_bytes:]
 
-def getInt(data, offset, debug=False, num_bytes=2):
-    if debug: print(f"current value: {int.from_bytes(data[offset:offset+num_bytes], 'little', signed=False)}")
-    return int.from_bytes(data[offset:offset+num_bytes], 'little')
+def getInt(data, offset, debug=False, num_bytes=2, signed=False):
+    if debug:
+        current_val = int.from_bytes(
+            data[offset:offset+num_bytes], 'little', signed=signed
+        )
+        print(f"current value: {current_val}")
+    return int.from_bytes(data[offset:offset+num_bytes], 'little', signed=signed)
 
 def updateSecrets(data, secret_list):
     secret_count = getSecretCount(data)


### PR DESCRIPTION
## Summary
- add a Stats tab that exposes mom kills, deaths, best streak, and online best streak for editing
- introduce a Bestiary tab with editable values for key enemies and helper utilities to read/write the save data safely
- update numeric read/write helpers to respect signed configuration so streak values persist correctly

## Testing
- python -m compileall isaac_savefile_editor.py script.py

------
https://chatgpt.com/codex/tasks/task_e_68e2895eff50833296eee1e29fac6857